### PR TITLE
Feature - Collapsible Pull Requests

### DIFF
--- a/src/popup/components/PRDisplay/RepoSection/RepoTitle.jsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoTitle.jsx
@@ -1,31 +1,65 @@
 /* global chrome */
 import React from "react";
 import Box from "@mui/material/Box";
+import ExpandMore from "@mui/icons-material/ExpandMore";
+import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 
 export default function RepoTitle({ repo }) {
   return (
     <Box
       sx={{
-        display: "flex",
-        justifyContent: "center",
-        borderBottom: "1px solid whitesmoke",
         width: "100%",
-        "&:hover": {
-          cursor: "pointer",
-          bgcolor: "whitesmoke",
-        },
+        display: "flex",
+        flexDirection: "row",
         padding: 1,
-      }}
-      onClick={() => {
-        chrome.tabs.create({
-          url: repo.url,
-        });
+        borderBottom: "1px solid whitesmoke",
       }}
     >
-      <Typography variant="subtitle1" sx={{ fontWeight: "bold" }}>
-        {`${repo.owner}/${repo.name}`}
-      </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          flex: 1,
+          justifyContent: "center",
+          gap: 1,
+        }}
+        onClick={() => {
+          chrome.tabs.create({
+            url: repo.url,
+          });
+        }}
+      >
+        <Typography variant="subtitle1" sx={{ fontWeight: "bold" }}>
+          {`${repo.owner}/${repo.name}`}
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          flex: 0,
+        }}
+      >
+        <IconButton
+          sx={{
+            "&:hover": {
+              bgcolor: "transparent",
+            },
+          }}
+        >
+          <ExpandMore
+            sx={{
+              fontSize: 16,
+              color: "rgba(119, 119, 119, 0.5)",
+              "&:hover": {
+                color: "rgba(119, 119, 119, 0.75)",
+              },
+              "&:active": {
+                color: "rgba(119, 119, 119, 1)",
+              },
+            }}
+          />
+        </IconButton>
+      </Box>
     </Box>
   );
 }

--- a/src/popup/components/PRDisplay/RepoSection/index.jsx
+++ b/src/popup/components/PRDisplay/RepoSection/index.jsx
@@ -1,4 +1,7 @@
 import React from "react";
+import Accordion from "@mui/material/Accordion";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import AccordionDetails from "@mui/material/AccordionDetails";
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import PullRequest from "./PullRequest";
@@ -13,15 +16,48 @@ export default function RepoSection({ repo, filter }) {
 
   return (
     <Box>
-      <RepoTitle repo={repo} />
-      <Stack width="100%" spacing={0}>
-        {prsToShow &&
-          prsToShow.length > 0 &&
-          prsToShow.map((pullRequest) => (
-            <PullRequest key={pullRequest.url} pr={pullRequest} />
-          ))}
-        {prsToShow && prsToShow.length <= 0 && <NoPullRequest repo={repo} />}
-      </Stack>
+      <Accordion elevation={0} disableGutters square>
+        <AccordionSummary
+          sx={{
+            padding: 0,
+            "& .MuiAccordionSummary-content": {
+              margin: 0,
+            },
+          }}
+        >
+          <Stack
+            width="100%"
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            sx={{
+              "&:hover": {
+                cursor: "pointer",
+                bgcolor: "whitesmoke",
+              },
+            }}
+          >
+            <RepoTitle repo={repo} />
+          </Stack>
+        </AccordionSummary>
+        <AccordionDetails
+          sx={{
+            margin: 0,
+            padding: 0,
+          }}
+        >
+          <Stack width="100%" spacing={0}>
+            {prsToShow &&
+              prsToShow.length > 0 &&
+              prsToShow.map((pullRequest) => (
+                <PullRequest key={pullRequest.url} pr={pullRequest} />
+              ))}
+            {prsToShow && prsToShow.length <= 0 && (
+              <NoPullRequest repo={repo} />
+            )}
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
     </Box>
   );
 }

--- a/src/popup/components/PRDisplay/index.jsx
+++ b/src/popup/components/PRDisplay/index.jsx
@@ -1,4 +1,3 @@
-/** global chrome */
 import React, { useEffect, useState } from "react";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";


### PR DESCRIPTION
### Summary

In this PR, the extension initially hides the PR's from view underneath the repo's title. This was added to handle situations where there may be so many PR's open for a repo section that makes it harder to navigate to other repo's PR's.

### Changes

- Added the Accordion component for use in the RepoSection component
- Updated layout of RepoTitle
- Moved opening tab to repo's homepage to just the Box surrounding the title
