### PR TITLE
Refactor - Using WebExtension-Polyfills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "regenerator-runtime": "^0.13.10",
+        "webextension-polyfill": "^0.10.0",
         "webpack": "^5.70.0",
         "webpack-cli": "^4.9.2",
         "webpack-merge": "^5.8.0"
@@ -7053,6 +7054,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
+    },
     "node_modules/webpack": {
       "version": "5.72.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
@@ -12239,6 +12245,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
     },
     "webpack": {
       "version": "5.72.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "regenerator-runtime": "^0.13.10",
+    "webextension-polyfill": "^0.10.0",
     "webpack": "^5.70.0",
     "webpack-cli": "^4.9.2",
     "webpack-merge": "^5.8.0"

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,36 +1,36 @@
-/* global chrome */
+import Browser from "webextension-polyfill";
+import "regenerator-runtime";
 import GitHubClient from "../data/index";
-
-require("regenerator-runtime");
-
-const {
+import {
   getToken,
   clearStorage,
   getRepositories,
   setBadge,
-} = require("../data/extension");
+} from "../data/extension";
 
 const alarmName = "fetchPRs";
 const delayInMinutes = 0;
 const periodInMinutes = 1;
 
 // Install logic
-chrome.runtime.onInstalled.addListener(async () => {
+Browser.runtime.onInstalled.addListener(async () => {
   console.log("Installed!");
 
   console.log("Creating alarm...");
-  chrome.alarms.create(alarmName, {
+  Browser.alarms.create(alarmName, {
     delayInMinutes,
     periodInMinutes,
   });
-  console.log("Created!", await chrome.alarms.get(alarmName));
+  console.log("Created!", await Browser.alarms.get(alarmName));
 
   await clearStorage();
 });
 
 // Periodically fetch pull requests and update the badge
-chrome.alarms.onAlarm.addListener(async () => {
-  console.log("--- Start ---");
+Browser.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name !== alarmName) {
+    return;
+  }
   try {
     const token = await getToken();
     if (token === undefined) {
@@ -53,5 +53,4 @@ chrome.alarms.onAlarm.addListener(async () => {
     console.error(`There was an error in setting the badge`);
     console.error(e);
   }
-  console.log("--- End ---");
 });

--- a/src/data/extension.js
+++ b/src/data/extension.js
@@ -1,8 +1,11 @@
-/* global chrome */
 /**
- * This file is responsible for any functions related to reading and
- * writing data to Chrome's storage system.
+ * This file is responsible for any functions related to interacting with
+ * the extension's storage, interface, action, etc.
+ * With the use of the webextension-polyfill package, most functionality defined
+ * here will work across both Chrome and Firefox.
  */
+
+import Browser from "webextension-polyfill";
 
 /**
  * The storage key for this extension.
@@ -16,7 +19,7 @@ const storageKey = "ghpr-ext";
  * @returns the storage object
  */
 export async function getStorage() {
-  const storage = await chrome.storage.sync.get([storageKey]);
+  const storage = await Browser.storage.sync.get([storageKey]);
   return storage[storageKey];
 }
 
@@ -24,7 +27,7 @@ export async function getStorage() {
  * Clears the storage values for this extension
  */
 export async function clearStorage() {
-  await chrome.storage.sync.set({ [storageKey]: {} });
+  await Browser.storage.sync.set({ [storageKey]: {} });
   console.log("ghpr-ext cleared.");
 }
 
@@ -33,7 +36,7 @@ export async function clearStorage() {
  * @param {object} value The new update storage object
  */
 export async function setStorage(value) {
-  await chrome.storage.sync.set({ [storageKey]: value });
+  await Browser.storage.sync.set({ [storageKey]: value });
 }
 
 /**
@@ -106,10 +109,10 @@ export async function getToken() {
  * @param {string} text The contents of the badge, will be converted into a string
  */
 export function setBadge(text) {
-  chrome.action.setBadgeText({
+  Browser.action.setBadgeText({
     text: `${text}`,
   });
-  chrome.action.setBadgeBackgroundColor({
+  Browser.action.setBadgeBackgroundColor({
     color: "black",
   });
 }
@@ -119,7 +122,7 @@ export function setBadge(text) {
  * @param {string} url The URL to navigate to in the new tab
  */
 export function createTab(url) {
-  chrome.tabs.create({
+  Browser.tabs.create({
     url: `${url}`,
   });
 }


### PR DESCRIPTION
### Summary

In this PR, all extension API related code has been replaced with using the `webextension-polyfills` package. This allows for the extension to be functional on other browsers other than Chrome. However, this PR does not properly build the project as a Firefox add-on yet.

### Changes
- Installed `webextension-polyfills`
- Replaced all `chrome.` calls with `Browser.` from the new package
