### PR TITLE
Feature - Multiple JIRA Tags

### DIFF
--- a/src/data/extension.js
+++ b/src/data/extension.js
@@ -43,13 +43,13 @@ export async function setStorage(value) {
  * Adds a repository's url to chrome storage. If the repository is already added,
  * then this function will do nothing.
  */
-export async function addRepository(repoUrl, jiraTag, jiraDomain) {
+export async function addRepository(repoUrl, jiraTags, jiraDomain) {
   const repoToAdd = {
     url: repoUrl,
   };
 
-  if (jiraTag && jiraDomain) {
-    repoToAdd.jiraTag = jiraTag;
+  if (jiraTags && jiraDomain) {
+    repoToAdd.jiraTags = jiraTags;
     repoToAdd.jiraDomain = jiraDomain;
   }
 

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -54,7 +54,7 @@ export default class GitHubClient {
    * If JIRA information was specified, this function will provide a URL to the JIRA ticket on success.
    * @param reposData - An array where each element is an object of repo data, containing the url, jiraTag, and jiraDomain
    * url - The url to the repository's main page (ex: https://github.com/syj67507/discord-bot)
-   * jiraTag - The JIRA project tag
+   * jiraTags - An array of JIRA project tags
    * jiraDomain - The base domain for the JIRA project
    * @returns An array of repository information and it's pull request data
    */

--- a/src/popup/components/Options/components/Add/index.jsx
+++ b/src/popup/components/Options/components/Add/index.jsx
@@ -6,11 +6,11 @@ import { addRepository } from "../../../../../data/extension";
 
 export default function Add() {
   const [repository, setRepository] = useState("");
-  const [jiraTag, setJiraTag] = useState("");
+  const [rawJiraTags, setRawJiraTags] = useState("");
   const [jiraDomain, setJiraDomain] = useState("");
 
-  const saveEnabled1 = repository && !jiraTag && !jiraDomain; // only repository field
-  const saveEnabled2 = repository && jiraTag && jiraDomain; // specify both jira tags
+  const saveEnabled1 = repository && !rawJiraTags && !jiraDomain; // only repository field
+  const saveEnabled2 = repository && rawJiraTags && jiraDomain; // specify both jira tags
   const saveEnabled = saveEnabled1 || saveEnabled2;
 
   return (
@@ -24,7 +24,7 @@ export default function Add() {
     >
       <TextField
         label="Repository URL"
-        helperText="https://github.com/<username>/<repositoryName>"
+        placeholder="https://github.com/<username>/<repositoryName>"
         variant="standard"
         value={repository}
         onChange={(e) => {
@@ -33,18 +33,21 @@ export default function Add() {
         fullWidth
       />
       <TextField
-        label="JIRA Tag (optional)"
+        label="(Optional) JIRA Project Tag"
         helperText="'TAG' as in TAG-1234"
+        placeholder="TAG,PROJ,..."
         variant="standard"
-        value={jiraTag}
+        value={rawJiraTags}
         onChange={(e) => {
-          setJiraTag(e.target.value);
+          setRawJiraTags(e.target.value);
         }}
         fullWidth
       />
       <TextField
-        label="JIRA Domain (optional)"
-        helperText="Domain to build the url to JIRA ticket [domain]/browse/TAG-1234"
+        label="(Optional) JIRA Domain"
+        helperText={`Domain to build the url to JIRA ticket ${
+          jiraDomain || "<domain>"
+        }/browse/TAG-1234`}
         placeholder="https://jira.company.com"
         variant="standard"
         value={jiraDomain}
@@ -59,7 +62,8 @@ export default function Add() {
           color="error"
           onClick={async () => {
             setRepository("");
-            setJiraTag("");
+            setRawJiraTags("");
+            setJiraDomain("");
           }}
           sx={{
             bgcolor: "whitesmoke",
@@ -76,7 +80,7 @@ export default function Add() {
           variant="contained"
           disabled={!saveEnabled}
           onClick={async () => {
-            await addRepository(repository, jiraTag, jiraDomain);
+            await addRepository(repository, rawJiraTags.split(","), jiraDomain);
           }}
           sx={{
             bgcolor: "#6cc644",

--- a/src/popup/components/Options/components/Saved/SavedRepo/index.jsx
+++ b/src/popup/components/Options/components/Saved/SavedRepo/index.jsx
@@ -17,8 +17,8 @@ export default function SavedRepo({ repo, onRemove, bgcolor }) {
         {repo.jiraDomain && (
           <Typography variant="caption">{repo.jiraDomain}</Typography>
         )}
-        {repo.jiraTag && (
-          <Typography variant="caption">{repo.jiraTag}</Typography>
+        {repo.jiraTags && (
+          <Typography variant="caption">{repo.jiraTags.join(",")}</Typography>
         )}
       </Stack>
 


### PR DESCRIPTION
### Summary

In this PR, each repository can now be configured with more than one JIRA tag. Each additional tag can be defined by placing a comma in between each JIRA tag.

Example
```
One tag: "FOO"
Two tags: "FOO,BAR"
```

### Changes
- `jiraTag` property name changed to `jiraTags`
- `TextField` component prompts for adding a repository have better descriptions
- Refactored parsing of JIRA tickets in pull request data for multiple tags
- Viewing saved repos updated to parse multiple tags
