### PR TITLE
Refactor - Switch Open Tab and Expand Behavior

### DIFF
--- a/src/popup/components/PRDisplay/RepoSection/RepoTitle.jsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoTitle.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Box from "@mui/material/Box";
-import ExpandMore from "@mui/icons-material/ExpandMore";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 import { createTab } from "../../../../data/extension";
@@ -24,9 +24,6 @@ export default function RepoTitle({ repo }) {
           justifyContent: "center",
           gap: 1,
         }}
-        onClick={() => {
-          createTab(repo.url);
-        }}
       >
         <Typography variant="subtitle1" sx={{ fontWeight: "bold" }}>
           {`${repo.owner}/${repo.name}`}
@@ -43,8 +40,11 @@ export default function RepoTitle({ repo }) {
               bgcolor: "transparent",
             },
           }}
+          onClick={() => {
+            createTab(repo.url);
+          }}
         >
-          <ExpandMore
+          <OpenInNewIcon
             sx={{
               fontSize: 16,
               color: "rgba(119, 119, 119, 0.5)",

--- a/src/popup/components/PRDisplay/RepoSection/RepoTitle.jsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoTitle.jsx
@@ -2,62 +2,69 @@ import React from "react";
 import Box from "@mui/material/Box";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { createTab } from "../../../../data/extension";
 
 export default function RepoTitle({ repo }) {
   return (
-    <Box
-      sx={{
-        width: "100%",
-        display: "flex",
-        flexDirection: "row",
-        padding: 1,
-        borderBottom: "1px solid whitesmoke",
-      }}
+    <Tooltip
+      title={`${repo.pullRequests.length} open`}
+      followCursor
+      disableInteractive
     >
       <Box
         sx={{
+          width: "100%",
           display: "flex",
           flexDirection: "row",
-          flex: 1,
-          justifyContent: "center",
-          gap: 1,
+          padding: 1,
+          borderBottom: "1px solid whitesmoke",
         }}
       >
-        <Typography variant="subtitle1" sx={{ fontWeight: "bold" }}>
-          {`${repo.owner}/${repo.name}`}
-        </Typography>
-      </Box>
-      <Box
-        sx={{
-          flex: 0,
-        }}
-      >
-        <IconButton
+        <Box
           sx={{
-            "&:hover": {
-              bgcolor: "transparent",
-            },
-          }}
-          onClick={() => {
-            createTab(repo.url);
+            display: "flex",
+            flexDirection: "row",
+            flex: 1,
+            justifyContent: "center",
+            gap: 1,
           }}
         >
-          <OpenInNewIcon
+          <Typography variant="subtitle1" sx={{ fontWeight: "bold" }}>
+            {`${repo.owner}/${repo.name}`}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            flex: 0,
+          }}
+        >
+          <IconButton
             sx={{
-              fontSize: 16,
-              color: "rgba(119, 119, 119, 0.5)",
               "&:hover": {
-                color: "rgba(119, 119, 119, 0.75)",
-              },
-              "&:active": {
-                color: "rgba(119, 119, 119, 1)",
+                bgcolor: "transparent",
               },
             }}
-          />
-        </IconButton>
+            onClick={() => {
+              createTab(repo.url);
+            }}
+          >
+            <OpenInNewIcon
+              sx={{
+                fontSize: 16,
+                color: "rgba(119, 119, 119, 0.25)",
+                "&:hover": {
+                  color: "rgba(119, 119, 119, 0.75)",
+                },
+                "&:active": {
+                  color: "rgba(119, 119, 119, 1)",
+                },
+              }}
+            />
+          </IconButton>
+        </Box>
       </Box>
-    </Box>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
### Summary

In this PR, the icon for expanding has been switched out for a new tab icon indicating that clicking the button will now open the repo in a new tab. Clicking anywhere else on the repo's title will expand the dropdown allowing for view of the open PR's. This came about as making it easier to stay in the extension and not be brought to another screen accidentally.

### Changes
- Icon's changed
- Clicking title expands, clicking new tab icon brings up the repository in a new tab
- Tooltip used to describe how many PR's are open for a given repository
