### PR TITLE
Refactor - Convert src/background to TypeScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,6 @@
     "@typescript-eslint",
     "prettier"
   ],
-  "rules": {}
+  "rules": {},
+  "ignorePatterns": [ "webpack/**/*.js" ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^20.2.1",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
+        "@types/regenerator-runtime": "^0.13.1",
         "@types/webextension-polyfill": "^0.10.0",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "babel-loader": "^8.2.3",
@@ -2759,6 +2760,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/regenerator-runtime": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@types/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+      "integrity": "sha512-Wr4Kopo+zs7kl1mxveVrP7Hl5nEzauQKdSNFN5Eg27Ze11MAgJYKgidYc9AAkQzGXXWH9lqVzPbXUGH6M8VY6g==",
+      "dev": true
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -9720,6 +9727,12 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/regenerator-runtime": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@types/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz",
+      "integrity": "sha512-Wr4Kopo+zs7kl1mxveVrP7Hl5nEzauQKdSNFN5Eg27Ze11MAgJYKgidYc9AAkQzGXXWH9lqVzPbXUGH6M8VY6g==",
+      "dev": true
     },
     "@types/scheduler": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/node": "^20.2.1",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
+    "@types/regenerator-runtime": "^0.13.1",
     "@types/webextension-polyfill": "^0.10.0",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "babel-loader": "^8.2.3",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -13,6 +13,7 @@ const delayInMinutes = 0;
 const periodInMinutes = 1;
 
 // Install logic
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 Browser.runtime.onInstalled.addListener(async () => {
   console.log("Installed!");
 
@@ -27,6 +28,7 @@ Browser.runtime.onInstalled.addListener(async () => {
 });
 
 // Periodically fetch pull requests and update the badge
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 Browser.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name !== alarmName) {
     return;
@@ -48,7 +50,7 @@ Browser.alarms.onAlarm.addListener(async (alarm) => {
     reposData.forEach((repoData) => {
       count += repoData.pullRequests.length;
     });
-    setBadge(count);
+    await setBadge(count);
   } catch (e) {
     console.error(`There was an error in setting the badge`);
     console.error(e);

--- a/webpack/chrome/webpack.chrome.js
+++ b/webpack/chrome/webpack.chrome.js
@@ -5,7 +5,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 module.exports = {
   entry: {
     popup: "./src/popup/popup.jsx",
-    background: "./src/background/background.js",
+    background: "./src/background/background.ts",
   },
   output: {
     path: path.resolve(__dirname, "..", "..", "dist", "chrome"),

--- a/webpack/firefox/webpack.firefox.js
+++ b/webpack/firefox/webpack.firefox.js
@@ -5,7 +5,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 module.exports = {
   entry: {
     popup: "./src/popup/popup.jsx",
-    background: "./src/background/background.js",
+    background: "./src/background/background.ts",
   },
   output: {
     path: path.resolve(__dirname, "..", "..", "dist", "firefox"),


### PR DESCRIPTION
### Summary

In this PR, the `src/background` files have been converted into TypeScript. This is part of the refactor to convert all source code into TypeScript.

### Changes
- `background.js` converted to `background.ts`
- ESLint ignore overrides used for allowing asynchronous methods in the background script handlers
- webpack configurations updated to allow for the background entry point to reference the typescript file
- ESLint config updated to ignore webpack configurations
