### PR TITLE
Bugfix: Resets Storage on Install

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,7 +1,13 @@
 import Browser from "webextension-polyfill";
 import "regenerator-runtime";
 import GitHubClient from "../data/index";
-import { getToken, getRepositories, setBadge } from "../data/extension";
+import {
+  getToken,
+  getRepositories,
+  setBadge,
+  getStorage,
+  resetStorage,
+} from "../data/extension";
 
 const alarmName = "fetchPRs";
 const delayInMinutes = 0;
@@ -18,6 +24,13 @@ Browser.runtime.onInstalled.addListener(async () => {
     periodInMinutes,
   });
   console.log("Created!", await Browser.alarms.get(alarmName));
+
+  // Initializing storage
+  // Checking if it exists to not override previous data
+  if ((await getStorage()) === undefined) {
+    console.log("No storage data detected, resetting storage...");
+    await resetStorage();
+  }
 });
 
 // Periodically fetch pull requests and update the badge

--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -50,9 +50,9 @@ export async function getStorage(): Promise<Storage> {
 /**
  * Clears the storage values for this extension
  */
-export async function clearStorage(): Promise<void> {
+export async function resetStorage(): Promise<void> {
   await Browser.storage.sync.set({ [storageKey]: {} });
-  console.log("ghpr-ext cleared.");
+  console.log("ghpr-ext storage reset.");
 }
 
 /**

--- a/src/popup/components/Settings/ClearStorageSetting.tsx
+++ b/src/popup/components/Settings/ClearStorageSetting.tsx
@@ -15,7 +15,7 @@ export default function ClearStorageSetting() {
           variant="contained"
           color="error"
           onClick={() => {
-            browser.clearStorage().catch(() => {
+            browser.resetStorage().catch(() => {
               console.error("Failed to clear storage.");
             });
           }}


### PR DESCRIPTION
### Summary

In this PR, an issue where storage values could not be set has been resolved. The issue came from the fact that any `setStorage()` calls would error because the storage API didn't have an object initialized in place of where the values would be set.

Previously the `clearStorage()` (now renamed to `resetStorage()` was removed from the `onInstall` event of the background script to prevent pre-existing data from being cleared. This would mean that there was no object initialized for storage that caused the `setStorage()` calls to fail. Now this event will check to see if there is any pre-existing data, and call a reset to initialize the storage object if there isn't any.

### Changes
- renamed `clearStorage()` to `resetStorage()`
- `onInstall` event calls `resetStorage()` if no pre-existing data is present
