### PR TITLE
Feature: Add Visual Feedback on Settings Page

### DIFF
--- a/src/popup/components/Settings/AccessTokenSetting.tsx
+++ b/src/popup/components/Settings/AccessTokenSetting.tsx
@@ -4,9 +4,18 @@ import Link from "@mui/material/Link";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import React, { useState } from "react";
+import { type AlertColor } from "@mui/material/Alert";
 import * as browser from "../../../data/extension";
 
-export default function AccessTokenSetting() {
+interface AccessTokenSettingProps {
+  setAlertType: React.Dispatch<React.SetStateAction<AlertColor | "none">>;
+  setAlertMessage: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function AccessTokenSetting({
+  setAlertType,
+  setAlertMessage,
+}: AccessTokenSettingProps) {
   const [token, setToken] = useState("");
 
   return (
@@ -42,9 +51,18 @@ export default function AccessTokenSetting() {
         <Button
           variant="contained"
           onClick={() => {
-            browser.setToken(token).catch(() => {
-              console.error("Failed to save personal access token");
-            });
+            browser
+              .setToken(token)
+              .then(() => {
+                setAlertType("success");
+                setAlertMessage("Personal access token saved!");
+                setToken("");
+              })
+              .catch(() => {
+                console.error("Failed to save personal access token");
+                setAlertType("error");
+                setAlertMessage("Failed to save personal access token.");
+              });
           }}
           disabled={token === ""}
         >

--- a/src/popup/components/Settings/ClearStorageSetting.tsx
+++ b/src/popup/components/Settings/ClearStorageSetting.tsx
@@ -2,22 +2,39 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import React from "react";
+import { type AlertColor } from "@mui/material/Alert";
 import * as browser from "../../../data/extension";
 
-export default function ClearStorageSetting() {
+interface ClearStorageSettingProps {
+  setAlertType: React.Dispatch<React.SetStateAction<AlertColor | "none">>;
+  setAlertMessage: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function ClearStorageSetting({
+  setAlertType,
+  setAlertMessage,
+}: ClearStorageSettingProps) {
   return (
     <Stack direction="column" width="100%" padding={2} spacing={2}>
       <Typography variant="body1" textAlign="center">
-        Any issues may stem from invalid storage data. Clear the storage here.
+        Any issues may stem from invalid storage data. Reset the storage here.
       </Typography>
       <Stack width="100%" direction="row" justifyContent="flex-end" spacing={2}>
         <Button
           variant="contained"
           color="error"
           onClick={() => {
-            browser.resetStorage().catch(() => {
-              console.error("Failed to clear storage.");
-            });
+            browser
+              .resetStorage()
+              .then(() => {
+                setAlertType("success");
+                setAlertMessage("Storage reset!");
+              })
+              .catch(() => {
+                console.error("Failed to reset storage.");
+                setAlertType("error");
+                setAlertMessage("Failed to reset storage.");
+              });
           }}
         >
           Clear

--- a/src/popup/components/Settings/ResetStorageSetting.tsx
+++ b/src/popup/components/Settings/ResetStorageSetting.tsx
@@ -10,7 +10,7 @@ interface ClearStorageSettingProps {
   setAlertMessage: React.Dispatch<React.SetStateAction<string>>;
 }
 
-export default function ClearStorageSetting({
+export default function ResetStorageSetting({
   setAlertType,
   setAlertMessage,
 }: ClearStorageSettingProps) {

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -11,17 +11,16 @@ export default function Settings() {
   return (
     <Stack width="100%">
       {alertType !== "none" && (
-        <Alert
-          severity={alertType}
-          onClose={() => {
-            setAlertType("none");
-          }}
-          sx={{
-            margin: 1,
-          }}
-        >
-          {alertMessage}
-        </Alert>
+        <Stack padding={1}>
+          <Alert
+            severity={alertType}
+            onClose={() => {
+              setAlertType("none");
+            }}
+          >
+            {alertMessage} - Shams
+          </Alert>
+        </Stack>
       )}
       <AccessTokenSetting
         setAlertType={setAlertType}

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -1,12 +1,36 @@
-import React from "react";
+import React, { useState } from "react";
+import Alert, { type AlertColor } from "@mui/material/Alert";
+import Stack from "@mui/material/Stack";
 import ClearStorageSetting from "./ClearStorageSetting";
 import AccessTokenSetting from "./AccessTokenSetting";
 
 export default function Settings() {
+  const [alertType, setAlertType] = useState<AlertColor | "none">("none");
+  const [alertMessage, setAlertMessage] = useState("");
+
   return (
-    <>
-      <AccessTokenSetting />
-      <ClearStorageSetting />
-    </>
+    <Stack width="100%">
+      {alertType !== "none" && (
+        <Alert
+          severity={alertType}
+          onClose={() => {
+            setAlertType("none");
+          }}
+          sx={{
+            margin: 1,
+          }}
+        >
+          {alertMessage}
+        </Alert>
+      )}
+      <AccessTokenSetting
+        setAlertType={setAlertType}
+        setAlertMessage={setAlertMessage}
+      />
+      <ClearStorageSetting
+        setAlertType={setAlertType}
+        setAlertMessage={setAlertMessage}
+      />
+    </Stack>
   );
 }

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Alert, { type AlertColor } from "@mui/material/Alert";
 import Stack from "@mui/material/Stack";
-import ClearStorageSetting from "./ClearStorageSetting";
+import ResetStorageSetting from "./ResetStorageSetting";
 import AccessTokenSetting from "./AccessTokenSetting";
 
 export default function Settings() {
@@ -18,7 +18,7 @@ export default function Settings() {
               setAlertType("none");
             }}
           >
-            {alertMessage} - Shams
+            {alertMessage}
           </Alert>
         </Stack>
       )}
@@ -26,7 +26,7 @@ export default function Settings() {
         setAlertType={setAlertType}
         setAlertMessage={setAlertMessage}
       />
-      <ClearStorageSetting
+      <ResetStorageSetting
         setAlertType={setAlertType}
         setAlertMessage={setAlertMessage}
       />


### PR DESCRIPTION
### Summary

In this PR, alerts now appear at the top of the page when manipulating the settings. When a user attempts to save their token or reset their storage, there will be either a success or error alert depending on whether or not the action was successful.

### Changes
- Added Alert component logic to be displayed at the base of the settings component
- Inner settings component now takes in props for the alert state so that it can properly send information on what alert to show

### Screenshots
<details><summary>Click to open / close</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/673bffd6-726a-4041-a948-638bae47202d)


</p>
</details> 