### PR TITLE
Refactor: Version Detected when Building Release

### DIFF
--- a/.github/scripts/update-manifest-version.js
+++ b/.github/scripts/update-manifest-version.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+
+// Get the version string from command line
+const version = process.argv[2].replace("v", "");
+
+const manifestFiles = fs
+    .readdirSync("./public")
+    .filter(file => new RegExp("^manifest\..+\.json$", "g").test(file));
+
+for (const manifestFile of manifestFiles) {
+    const manifestFileContents = fs.readFileSync(`./public/${manifestFile}`).toString();
+    const updatedManifestFile = manifestFileContents.replace('"version": "0.0.3",', `"version": "${version}",`);
+
+    fs.writeFileSync(`./public/${manifestFile}`, updatedManifestFile);
+    console.log(`Updated ${manifestFile} version field to`, version);
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
+      
+      - name: Update version field in manifest files
+        run: node .github/scripts/update-manifest-version.js ${{ github.ref_name }}
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
### Summary

In this PR, the Release Extension job within GitHub actions have been updated. The action now runs a script to update the version of the manifest files needed for the extension / add-on. Before this change, a separate PR was needed in order to update the version in these files. That will no longer be needed since it will be passed upon creating the release tag.

### Changes
- new script `update-manifest-version.js`
- `release.yaml` updated to use the new script