### PR TITLE
Revamp: Settings UI

### DIFF
--- a/src/popup/components/Buttons/ClearButton.tsx
+++ b/src/popup/components/Buttons/ClearButton.tsx
@@ -1,0 +1,20 @@
+import { Button, type ButtonProps } from "@mui/material";
+import React from "react";
+
+export default function ClearButton(props: ButtonProps) {
+  return (
+    <Button
+      variant="outlined"
+      disableRipple
+      color="error"
+      sx={{
+        borderRadius: 2,
+        textTransform: "none",
+      }}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    >
+      Clear
+    </Button>
+  );
+}

--- a/src/popup/components/Buttons/SaveButton.tsx
+++ b/src/popup/components/Buttons/SaveButton.tsx
@@ -1,0 +1,27 @@
+import { Button, type ButtonProps } from "@mui/material";
+import React from "react";
+
+export default function SaveButton(props: ButtonProps) {
+  return (
+    <Button
+      variant="outlined"
+      disableRipple
+      sx={{
+        borderRadius: 2,
+        textTransform: "none",
+        color: "white",
+        bgcolor: "#1f883d",
+        "&:hover": {
+          bgcolor: "#1c823b",
+        },
+        "&.Mui-disabled": {
+          bgcolor: "white",
+        },
+      }}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    >
+      Save
+    </Button>
+  );
+}

--- a/src/popup/components/PRDisplay/Filters/Filters.tsx
+++ b/src/popup/components/PRDisplay/Filters/Filters.tsx
@@ -29,7 +29,7 @@ interface FiltersProps {
 
 export default function Filters({ filters, setFilters }: FiltersProps) {
   return (
-    <Card>
+    <Card sx={{ bgcolor: "white" }}>
       <TextField
         variant="outlined"
         size="small"

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
@@ -3,7 +3,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import JiraIconButton from "./JiraIconButton";
 import GitHubIconButton from "./GitHubIconButton";
-import type { PullRequestData, RepoData } from "../../../../../data";
+import type { PullRequestData } from "../../../../../data";
 
 interface PullRequestProps {
   pr: PullRequestData;

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -110,7 +110,7 @@ export default function PRDisplay() {
             );
           })}
         {data != null && data.length === 0 && (
-          <Card>
+          <Card sx={{ bgcolor: "white" }}>
             <Typography variant="body1" textAlign="left">
               Configure a repository under the Repos menu to start viewing pull
               requests for your favorite repositories!

--- a/src/popup/components/RepoOptions/components/Add/index.tsx
+++ b/src/popup/components/RepoOptions/components/Add/index.tsx
@@ -94,8 +94,7 @@ export default function Add({ onSave }: AddProps) {
             onSave(repository, jiraTagsSanizited, jiraDomainSanizited).catch(
               (e) => {
                 console.error(
-                  `failed to save repo ${repository}, ${jiraDomain}, ${rawJiraTags}
-                          }`,
+                  `failed to save repo ${repository}, ${jiraDomain}, ${rawJiraTags}`,
                   e
                 );
               }

--- a/src/popup/components/RepoOptions/components/Add/index.tsx
+++ b/src/popup/components/RepoOptions/components/Add/index.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { type ConfiguredRepo } from "../../../../../data/extension";
+import SaveButton from "../../../Buttons/SaveButton";
+import ClearButton from "../../../Buttons/ClearButton";
 
 interface AddProps {
   onSave: (
@@ -75,29 +76,14 @@ export default function Add({ onSave }: AddProps) {
         size="small"
       />
       <Stack width="100%" direction="row" justifyContent="flex-end" spacing={2}>
-        <Button
-          variant="outlined"
-          color="error"
+        <ClearButton
           onClick={() => {
             setRepository("");
             setRawJiraTags("");
             setJiraDomain("");
           }}
-          disableRipple
-          sx={{
-            borderRadius: 2,
-            textTransform: "none",
-            color: "#555a78",
-            bgcolor: "#f3fbfb",
-            "&:hover": {
-              bgcolor: "#f3fbfb",
-            },
-          }}
-        >
-          Clear
-        </Button>
-        <Button
-          variant="outlined"
+        />
+        <SaveButton
           disabled={!saveEnabled}
           onClick={() => {
             // implementation of onSave passed in as prop from Repos component
@@ -109,28 +95,13 @@ export default function Add({ onSave }: AddProps) {
               (e) => {
                 console.error(
                   `failed to save repo ${repository}, ${jiraDomain}, ${rawJiraTags}
-                  }`,
+                          }`,
                   e
                 );
               }
             );
           }}
-          disableRipple
-          sx={{
-            borderRadius: 2,
-            textTransform: "none",
-            color: "white",
-            bgcolor: "#1f883d",
-            "&:hover": {
-              bgcolor: "#1c823b",
-            },
-            "&.Mui-disabled": {
-              bgcolor: "white",
-            },
-          }}
-        >
-          Save
-        </Button>
+        />
       </Stack>
     </Stack>
   );

--- a/src/popup/components/Settings/AccessTokenSetting.tsx
+++ b/src/popup/components/Settings/AccessTokenSetting.tsx
@@ -4,19 +4,13 @@ import Link from "@mui/material/Link";
 import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
 import React, { useState } from "react";
-import { type AlertColor } from "@mui/material/Alert";
+import Snackbar from "@mui/material/Snackbar";
 import * as browser from "../../../data/extension";
 
-interface AccessTokenSettingProps {
-  setAlertType: React.Dispatch<React.SetStateAction<AlertColor | "none">>;
-  setAlertMessage: React.Dispatch<React.SetStateAction<string>>;
-}
-
-export default function AccessTokenSetting({
-  setAlertType,
-  setAlertMessage,
-}: AccessTokenSettingProps) {
+export default function AccessTokenSetting() {
   const [token, setToken] = useState("");
+  const [open, setOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
 
   return (
     <Stack direction="column" width="100%" padding={1} spacing={2}>
@@ -28,7 +22,7 @@ export default function AccessTokenSetting({
         target="_blank" // new tab
         textAlign="left"
         variant="body1"
-        href="https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+        href="https://docs.github.com/en/enterprise-server@3.12/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token"
       >
         Click here for more information
       </Link>
@@ -48,14 +42,14 @@ export default function AccessTokenSetting({
             browser
               .setToken(token)
               .then(() => {
-                setAlertType("success");
-                setAlertMessage("Personal access token saved!");
+                setToastMessage("Personal access token saved!");
+                setOpen(true);
                 setToken("");
               })
               .catch(() => {
+                setToastMessage("Failed to save personal access token.");
+                setOpen(true);
                 console.error("Failed to save personal access token");
-                setAlertType("error");
-                setAlertMessage("Failed to save personal access token.");
               });
           }}
           disabled={token === ""}
@@ -63,6 +57,20 @@ export default function AccessTokenSetting({
           Save
         </Button>
       </Stack>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+        }}
+        key="bottomleft"
+        sx={{
+          width: "fit-content",
+          borderRadius: 10,
+        }}
+        autoHideDuration={2000}
+        message={toastMessage}
+      />
     </Stack>
   );
 }

--- a/src/popup/components/Settings/AccessTokenSetting.tsx
+++ b/src/popup/components/Settings/AccessTokenSetting.tsx
@@ -2,10 +2,10 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
 import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
 import React, { useState } from "react";
 import Snackbar from "@mui/material/Snackbar";
 import * as browser from "../../../data/extension";
+import SaveButton from "../Buttons/SaveButton";
 
 export default function AccessTokenSetting() {
   const [token, setToken] = useState("");
@@ -36,8 +36,7 @@ export default function AccessTokenSetting() {
         }}
       />
       <Stack width="100%" direction="row" justifyContent="flex-end" spacing={2}>
-        <Button
-          variant="contained"
+        <SaveButton
           onClick={() => {
             browser
               .setToken(token)
@@ -53,9 +52,7 @@ export default function AccessTokenSetting() {
               });
           }}
           disabled={token === ""}
-        >
-          Save
-        </Button>
+        />
       </Stack>
       <Snackbar
         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}

--- a/src/popup/components/Settings/AccessTokenSetting.tsx
+++ b/src/popup/components/Settings/AccessTokenSetting.tsx
@@ -19,20 +19,14 @@ export default function AccessTokenSetting({
   const [token, setToken] = useState("");
 
   return (
-    <Stack
-      direction="column"
-      width="100%"
-      padding={2}
-      spacing={2}
-      borderBottom="1px solid whitesmoke"
-    >
-      <Typography variant="body1" textAlign="center">
+    <Stack direction="column" width="100%" padding={1} spacing={2}>
+      <Typography variant="body1" textAlign="left">
         Set your personal access token here. Create you personal access token
         under Developer Settings in your GitHub account.
       </Typography>
       <Link
         target="_blank" // new tab
-        textAlign="center"
+        textAlign="left"
         variant="body1"
         href="https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
       >

--- a/src/popup/components/Settings/ResetStorageSetting.tsx
+++ b/src/popup/components/Settings/ResetStorageSetting.tsx
@@ -1,19 +1,14 @@
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import React from "react";
-import { type AlertColor } from "@mui/material/Alert";
+import React, { useState } from "react";
+import Snackbar from "@mui/material/Snackbar";
 import * as browser from "../../../data/extension";
 
-interface ClearStorageSettingProps {
-  setAlertType: React.Dispatch<React.SetStateAction<AlertColor | "none">>;
-  setAlertMessage: React.Dispatch<React.SetStateAction<string>>;
-}
+export default function ResetStorageSetting() {
+  const [open, setOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
 
-export default function ResetStorageSetting({
-  setAlertType,
-  setAlertMessage,
-}: ClearStorageSettingProps) {
   return (
     <Stack direction="column" width="100%" padding={1} spacing={2}>
       <Typography variant="body1" textAlign="left">
@@ -27,19 +22,33 @@ export default function ResetStorageSetting({
             browser
               .resetStorage()
               .then(() => {
-                setAlertType("success");
-                setAlertMessage("Storage reset!");
+                setToastMessage("Storage reset!");
+                setOpen(true);
               })
               .catch(() => {
+                setToastMessage("Failed to reset storage.");
+                setOpen(true);
                 console.error("Failed to reset storage.");
-                setAlertType("error");
-                setAlertMessage("Failed to reset storage.");
               });
           }}
         >
           Clear
         </Button>
       </Stack>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+        }}
+        key="bottomleft"
+        sx={{
+          width: "fit-content",
+          borderRadius: 10,
+        }}
+        autoHideDuration={2000}
+        message={toastMessage}
+      />
     </Stack>
   );
 }

--- a/src/popup/components/Settings/ResetStorageSetting.tsx
+++ b/src/popup/components/Settings/ResetStorageSetting.tsx
@@ -15,8 +15,8 @@ export default function ResetStorageSetting({
   setAlertMessage,
 }: ClearStorageSettingProps) {
   return (
-    <Stack direction="column" width="100%" padding={2} spacing={2}>
-      <Typography variant="body1" textAlign="center">
+    <Stack direction="column" width="100%" padding={1} spacing={2}>
+      <Typography variant="body1" textAlign="left">
         Any issues may stem from invalid storage data. Reset the storage here.
       </Typography>
       <Stack width="100%" direction="row" justifyContent="flex-end" spacing={2}>

--- a/src/popup/components/Settings/ResetStorageSetting.tsx
+++ b/src/popup/components/Settings/ResetStorageSetting.tsx
@@ -1,9 +1,9 @@
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
 import React, { useState } from "react";
 import Snackbar from "@mui/material/Snackbar";
 import * as browser from "../../../data/extension";
+import ClearButton from "../Buttons/ClearButton";
 
 export default function ResetStorageSetting() {
   const [open, setOpen] = useState(false);
@@ -15,9 +15,7 @@ export default function ResetStorageSetting() {
         Any issues may stem from invalid storage data. Reset the storage here.
       </Typography>
       <Stack width="100%" direction="row" justifyContent="flex-end" spacing={2}>
-        <Button
-          variant="contained"
-          color="error"
+        <ClearButton
           onClick={() => {
             browser
               .resetStorage()
@@ -31,9 +29,7 @@ export default function ResetStorageSetting() {
                 console.error("Failed to reset storage.");
               });
           }}
-        >
-          Clear
-        </Button>
+        />
       </Stack>
       <Snackbar
         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Alert, { type AlertColor } from "@mui/material/Alert";
 import Stack from "@mui/material/Stack";
+import Card from "../Card/Card";
 import ResetStorageSetting from "./ResetStorageSetting";
 import AccessTokenSetting from "./AccessTokenSetting";
 
@@ -9,27 +10,29 @@ export default function Settings() {
   const [alertMessage, setAlertMessage] = useState("");
 
   return (
-    <Stack width="100%">
+    <Stack width="100%" padding={1} spacing={1}>
       {alertType !== "none" && (
-        <Stack padding={1}>
-          <Alert
-            severity={alertType}
-            onClose={() => {
-              setAlertType("none");
-            }}
-          >
-            {alertMessage}
-          </Alert>
-        </Stack>
+        <Alert
+          severity={alertType}
+          onClose={() => {
+            setAlertType("none");
+          }}
+        >
+          {alertMessage}
+        </Alert>
       )}
-      <AccessTokenSetting
-        setAlertType={setAlertType}
-        setAlertMessage={setAlertMessage}
-      />
-      <ResetStorageSetting
-        setAlertType={setAlertType}
-        setAlertMessage={setAlertMessage}
-      />
+      <Card>
+        <AccessTokenSetting
+          setAlertType={setAlertType}
+          setAlertMessage={setAlertMessage}
+        />
+      </Card>
+      <Card>
+        <ResetStorageSetting
+          setAlertType={setAlertType}
+          setAlertMessage={setAlertMessage}
+        />
+      </Card>
     </Stack>
   );
 }

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -1,37 +1,17 @@
-import React, { useState } from "react";
-import Alert, { type AlertColor } from "@mui/material/Alert";
+import React from "react";
 import Stack from "@mui/material/Stack";
 import Card from "../Card/Card";
 import ResetStorageSetting from "./ResetStorageSetting";
 import AccessTokenSetting from "./AccessTokenSetting";
 
 export default function Settings() {
-  const [alertType, setAlertType] = useState<AlertColor | "none">("none");
-  const [alertMessage, setAlertMessage] = useState("");
-
   return (
     <Stack width="100%" padding={1} spacing={1}>
-      {alertType !== "none" && (
-        <Alert
-          severity={alertType}
-          onClose={() => {
-            setAlertType("none");
-          }}
-        >
-          {alertMessage}
-        </Alert>
-      )}
       <Card>
-        <AccessTokenSetting
-          setAlertType={setAlertType}
-          setAlertMessage={setAlertMessage}
-        />
+        <AccessTokenSetting />
       </Card>
       <Card>
-        <ResetStorageSetting
-          setAlertType={setAlertType}
-          setAlertMessage={setAlertMessage}
-        />
+        <ResetStorageSetting />
       </Card>
     </Stack>
   );


### PR DESCRIPTION
### Summary

In this PR, the settings page has gotten a UI revamp. The page now splits each section into their own cards like the other pages. The alert message has been replaced with a snack bar / toast message that displays in the bottom left corner of the screen.

### Changes
- Alert messages replaced with snack bar / toast messages
- Card components have been reused and wraps around each section
- Alignment has been cleaned up to match the rest of the pages

### Screenshots

<details><summary>Click to see screenshots</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/a9eee649-3662-4c04-981a-a0b55fdb9f36)

</p>
</details> 