### PR TITLE
Feature: Filter Options Saved and Persisted

### DIFF
--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -38,7 +38,7 @@ export interface Storage {
   repos: ConfiguredRepo[];
   /** The GitHub personal access token */
   token: string;
-  /** Filters */
+  /** The current state of the user configured filters */
   filters: Filters;
 }
 
@@ -202,10 +202,10 @@ export async function saveFilterOptions(filters: Filters) {
 }
 
 /**
- * Returns the saved filter options that were previously set
+ * Returns the saved filter options that were previously set by the user
  * @returns The filter object
  */
-export async function getSavedFilterOptions() {
+export async function getFilterOptions() {
   const storage = await getStorage();
   return storage.filters;
 }

--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -38,6 +38,8 @@ export interface Storage {
   repos: ConfiguredRepo[];
   /** The GitHub personal access token */
   token: string;
+  /** Filters */
+  filters: Filters;
 }
 
 /**
@@ -178,4 +180,32 @@ export async function createTab(url: ConfiguredRepo["url"]): Promise<void> {
   await Browser.tabs.create({
     url: `${url}`,
   });
+}
+
+export interface Filters {
+  /** Determines whether to show the user's pull requests */
+  showMine: boolean;
+  /** Determines whether or not to include drafts in the display */
+  includeDrafts: boolean;
+  /** Text filter to look for pull requests that only have this text in it */
+  textFilter: string;
+}
+
+/**
+ * Saves the user's current state of the filtering options on the
+ * PR display page.
+ */
+export async function saveFilterOptions(filters: Filters) {
+  const storage = await getStorage();
+  storage.filters = filters;
+  await setStorage(storage);
+}
+
+/**
+ * Returns the saved filter options that were previously set
+ * @returns The filter object
+ */
+export async function getSavedFilterOptions() {
+  const storage = await getStorage();
+  return storage.filters;
 }

--- a/src/popup/components/PRDisplay/Filters/Filters.tsx
+++ b/src/popup/components/PRDisplay/Filters/Filters.tsx
@@ -1,4 +1,5 @@
-import { Typography } from "@mui/material";
+import { IconButton, Typography } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Stack from "@mui/material/Stack";
@@ -6,6 +7,7 @@ import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import React from "react";
 import Card from "../../Card/Card";
+import { saveFilterOptions } from "../../../../data/extension";
 
 interface FiltersProps {
   /** Object that contains the current state of user filters */
@@ -40,7 +42,38 @@ export default function Filters({ filters, setFilters }: FiltersProps) {
             ...filters,
             textFilter: e.target.value,
           });
+          saveFilterOptions({
+            ...filters,
+            textFilter: e.target.value,
+          }).catch((e) => {
+            console.error("failed to save filter state");
+          });
         }}
+        InputProps={{
+          endAdornment: (
+            <IconButton
+              sx={{
+                padding: 0, // set to 0 since padding of the button was expanding the textfield
+              }}
+              onClick={() => {
+                setFilters({
+                  ...filters,
+                  textFilter: "",
+                });
+                saveFilterOptions({
+                  ...filters,
+                  textFilter: "",
+                }).catch(() => {
+                  console.error("failed to save filter state");
+                });
+              }}
+            >
+              <ClearIcon />
+            </IconButton>
+          ),
+        }}
+        // apparently InputProps and inputProps are detected as duplicates
+        // eslint-disable-next-line react/jsx-no-duplicate-props
         inputProps={{
           style: { textAlign: "center", padding: 4 },
         }}
@@ -73,6 +106,12 @@ export default function Filters({ filters, setFilters }: FiltersProps) {
                     ...filters,
                     includeDrafts: !filters.includeDrafts,
                   });
+                  saveFilterOptions({
+                    ...filters,
+                    includeDrafts: !filters.includeDrafts,
+                  }).catch((e) => {
+                    console.error("failed to save filter state");
+                  });
                 }}
                 inputProps={{ "aria-label": "controlled" }}
               />
@@ -101,6 +140,12 @@ export default function Filters({ filters, setFilters }: FiltersProps) {
                   setFilters({
                     ...filters,
                     showMine: !filters.showMine,
+                  });
+                  saveFilterOptions({
+                    ...filters,
+                    showMine: !filters.showMine,
+                  }).catch((e) => {
+                    console.error("failed to save filter state");
                   });
                 }}
                 inputProps={{ "aria-label": "controlled" }}

--- a/src/popup/components/PRDisplay/Filters/Filters.tsx
+++ b/src/popup/components/PRDisplay/Filters/Filters.tsx
@@ -12,7 +12,7 @@ import { type Filters, saveFilterOptions } from "../../../../data/extension";
 interface FiltersProps {
   /**
    * Object that contains the current state of user filters that mirrors
-   * what was saved to this extensions storage
+   * what was saved to this extension's storage
    */
   filters: Filters;
   /** set function from the useState hook to set the state of the filters prop */

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -1,20 +1,12 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import GitHubClient, { type RepoData } from "../../../data";
 import RepoSection from "./RepoSection";
 import Loading from "../Loading";
-import {
-  getToken,
-  getRepositories,
-  setBadge,
-  saveFilterOptions,
-  getSavedFilterOptions,
-} from "../../../data/extension";
 import "regenerator-runtime";
 import PullRequest from "./RepoSection/PullRequest";
 import NoPullRequest from "./RepoSection/NoPullRequest";
-import Filters from "./Filters/Filters";
+import FilterOptions from "./Filters/Filters";
 import Card from "../Card/Card";
 import { useGetPullRequests, useSavedFilters } from "../../hooks";
 
@@ -26,7 +18,9 @@ export default function PRDisplay() {
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
       {/* Filtering search box */}
       {loadingFilters && <Loading />}
-      {!loadingFilters && <Filters filters={filters} setFilters={setFilters} />}
+      {!loadingFilters && (
+        <FilterOptions filters={filters} setFilters={setFilters} />
+      )}
       {loading && <Loading />}
       {/* TODO error message when fetching */}
       <Stack width="100%" spacing={1}>

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from "react";
 import {
   type Filters,
-  getSavedFilterOptions,
+  getFilterOptions,
   getRepositories,
   getToken,
   setBadge,
 } from "../data/extension";
 import GitHubClient, { type RepoData } from "../data";
 
+/**
+ * A hook to fetch the currently saved filtering options that was previously
+ * set by the user. If the call fails, then the default configuration
+ * for the filtering options will be returned instead
+ * @returns Returns a loadingFilters state variable, the filters themselves, and a setter for the filters
+ */
 export function useSavedFilters() {
   const defaultFilters: Filters = {
     textFilter: "",
@@ -21,7 +27,7 @@ export function useSavedFilters() {
   useEffect(() => {
     async function getFilters() {
       setLoadingFilters(true);
-      const savedFilters = await getSavedFilterOptions();
+      const savedFilters = await getFilterOptions();
       setFilters(savedFilters);
       setLoadingFilters(false);
     }
@@ -35,6 +41,10 @@ export function useSavedFilters() {
   return { loadingFilters, filters, setFilters };
 }
 
+/**
+ * A hook to fetch all pull requests for each repo that was configured by the user
+ * @returns Returns a loading state variable, the data, and the username
+ */
 export function useGetPullRequests() {
   const [username, setUsername] = useState("");
   const [data, setData] = useState<RepoData[] | null>(null);

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import {
+  type Filters,
+  getSavedFilterOptions,
+  getRepositories,
+  getToken,
+  setBadge,
+} from "../data/extension";
+import GitHubClient, { type RepoData } from "../data";
+
+export function useSavedFilters() {
+  const defaultFilters: Filters = {
+    textFilter: "",
+    includeDrafts: true,
+    showMine: false,
+  };
+
+  const [loadingFilters, setLoadingFilters] = useState(true);
+  const [filters, setFilters] = useState<Filters>(defaultFilters);
+
+  useEffect(() => {
+    async function getFilters() {
+      setLoadingFilters(true);
+      const savedFilters = await getSavedFilterOptions();
+      setFilters(savedFilters);
+      setLoadingFilters(false);
+    }
+    getFilters().catch((e) => {
+      setLoadingFilters(false);
+      setFilters(defaultFilters);
+      console.error(e);
+    });
+  }, []);
+
+  return { loadingFilters, filters, setFilters };
+}
+
+export function useGetPullRequests() {
+  const [username, setUsername] = useState("");
+  const [data, setData] = useState<RepoData[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  // const [error, setError] = useState(false); // TODO display error
+
+  useEffect(() => {
+    async function getPRs() {
+      try {
+        setLoading(true);
+
+        const token = await getToken();
+        const client = new GitHubClient(token);
+
+        // Fetch data
+        const storageRepos = await getRepositories();
+        const userPromise = client.getAuthenticatedUser();
+        const reposDataPromise = client.getRepoData(storageRepos);
+
+        // Using promise all to make calls in parallel
+        const [user, reposData] = await Promise.all([
+          userPromise,
+          reposDataPromise,
+        ]);
+
+        setUsername(user.username);
+        setData(reposData);
+        setLoading(false);
+
+        // Updates the browser action badge
+        let count = 0;
+        reposData.forEach((repoData) => {
+          count += repoData.pullRequests.length;
+        });
+        setBadge(count).catch((e) => {
+          console.error(`failed to set the badge to ${count}`, e);
+        });
+      } catch (e) {
+        console.error(e);
+        setLoading(false);
+        setData(null);
+        setUsername("");
+      }
+    }
+    getPRs().catch((e) => {
+      console.error(`failed to getPRs()`, e);
+    });
+  }, []);
+
+  return { username, data, loading };
+}


### PR DESCRIPTION
### Summary

In this PR, the filtering options that are present at the top of the PR Display page are now saved and persisted between uses of the extension / add-on.

### Changes
- Filter definitions have been moved to `extension.ts`
- Added functions to save and fetch filtering options to and from storage
- onChange handlers are reusing the same single handler, except for the text filter which uses a debounced version
- Data fetching in the base PRDisplay component now has its logic moved into a custom hook

