### PR TITLE
Bugfix: Filters wouldn't Load on First Use

### DIFF
--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -28,7 +28,7 @@ export function useSavedFilters() {
     async function getFilters() {
       setLoadingFilters(true);
       const savedFilters = await getFilterOptions();
-      setFilters(savedFilters);
+      setFilters(savedFilters ?? defaultFilters); // default to defaultFilters if not saved
       setLoadingFilters(false);
     }
     getFilters().catch((e) => {


### PR DESCRIPTION
### Summary

In this PR, the issue where the filters wouldn't load because there was no data when the extension / add-on was first installed has been fixed.

The issue stems from the call to the storage API was successful, but it would return undefined. A check has been introduced that falls back to a default configuration for these filtering options should it return undefined, similar to how we fall back when the call fails and returns an error.

### Changes
- Added a null coalescing check for when the filters are set on the UI
