### PR TITLE
Bugfix: CI/CD Creating Invalid Firefox Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
           cd dist
           cd chrome
           zip -r ../ghpr-ext-chrome-${{ github.ref_name }}.zip .
-          zip -r ../ghpr-ext-firefox-${{ github.ref_name }}.zip .
-          cd ../firefox
           tar -czf ../ghpr-ext-chrome-${{ github.ref_name }}.tgz .
+          cd ../firefox
+          zip -r ../ghpr-ext-firefox-${{ github.ref_name }}.zip .
           tar -czf ../ghpr-ext-firefox-${{ github.ref_name }}.tgz .
 
       - name: Upload Release


### PR DESCRIPTION
### Summary

There was an issue where firefox versions wouldn't load and it was due to creating the archives incorrectly. The firefox version was using the chrome version of the build and didn't have the proper manifest file.

### Changes
- Calling the creation of the archives in the correct folders now