### PR TITLE
Feature: More Descriptive Personal Access Token Instructions

### DIFF
--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import Stack from "@mui/material/Stack";
-import Typography from "@mui/material/Typography";
-import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Alert } from "@mui/material";
 import RepoSection from "./RepoSection";
 import Loading from "../Loading";
@@ -39,7 +37,7 @@ export default function PRDisplay() {
                 paddingY: 0,
               }}
             >
-              You haven't set your classic personal access token yet. Go to
+              You haven&apos;t set your classic personal access token yet. Go to
               settings and save your token so that you can see all your pull
               requests!
             </Alert>
@@ -94,7 +92,7 @@ export default function PRDisplay() {
                 paddingY: 0,
               }}
             >
-              You haven't configured any repositories yet. Configure a
+              You haven&apos;t configured any repositories yet. Configure a
               repository under the Repos menu to start viewing pull requests for
               your favorite repositories!
             </Alert>

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
+import Alert from "@mui/material/Alert";
 import Stack from "@mui/material/Stack";
-import { Alert } from "@mui/material";
 import RepoSection from "./RepoSection";
 import Loading from "../Loading";
 import "regenerator-runtime";
@@ -13,7 +13,7 @@ import { useGetPullRequests, useSavedFilters } from "../../hooks";
 export default function PRDisplay() {
   const { loadingFilters, filters, setFilters } = useSavedFilters();
   const { loading, data, username, token } = useGetPullRequests();
-  console.log("token", token);
+
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
       {/* Filtering search box */}

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import { Alert } from "@mui/material";
 import RepoSection from "./RepoSection";
 import Loading from "../Loading";
 import "regenerator-runtime";
@@ -12,8 +14,8 @@ import { useGetPullRequests, useSavedFilters } from "../../hooks";
 
 export default function PRDisplay() {
   const { loadingFilters, filters, setFilters } = useSavedFilters();
-  const { loading, data, username } = useGetPullRequests();
-
+  const { loading, data, username, token } = useGetPullRequests();
+  console.log("token", token);
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
       {/* Filtering search box */}
@@ -24,6 +26,24 @@ export default function PRDisplay() {
       {loading && <Loading />}
       {/* TODO error message when fetching */}
       <Stack width="100%" spacing={1}>
+        {token === undefined && (
+          <Card
+            sx={{
+              bgcolor: "#e5f6fd",
+            }}
+          >
+            <Alert
+              severity="info"
+              sx={{
+                paddingX: 1,
+                paddingY: 0,
+              }}
+            >
+              You haven't set your personal access token yet. Go to settings and
+              save your token so that you can see all your pull requests!
+            </Alert>
+          </Card>
+        )}
         {data != null &&
           data.length > 0 &&
           data.map((repo) => {
@@ -61,11 +81,22 @@ export default function PRDisplay() {
             );
           })}
         {data != null && data.length === 0 && (
-          <Card sx={{ bgcolor: "white" }}>
-            <Typography variant="body1" textAlign="left">
-              Configure a repository under the Repos menu to start viewing pull
-              requests for your favorite repositories!
-            </Typography>
+          <Card
+            sx={{
+              bgcolor: "#e5f6fd",
+            }}
+          >
+            <Alert
+              severity="info"
+              sx={{
+                paddingX: 1,
+                paddingY: 0,
+              }}
+            >
+              You haven't configured any repositories yet. Configure a
+              repository under the Repos menu to start viewing pull requests for
+              your favorite repositories!
+            </Alert>
           </Card>
         )}
       </Stack>

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -39,8 +39,9 @@ export default function PRDisplay() {
                 paddingY: 0,
               }}
             >
-              You haven't set your personal access token yet. Go to settings and
-              save your token so that you can see all your pull requests!
+              You haven't set your classic personal access token yet. Go to
+              settings and save your token so that you can see all your pull
+              requests!
             </Alert>
           </Card>
         )}

--- a/src/popup/components/Settings/AccessTokenSetting.tsx
+++ b/src/popup/components/Settings/AccessTokenSetting.tsx
@@ -15,8 +15,13 @@ export default function AccessTokenSetting() {
   return (
     <Stack direction="column" width="100%" padding={1} spacing={2}>
       <Typography variant="body1" textAlign="left">
-        Set your personal access token here. Create you personal access token
-        under Developer Settings in your GitHub account.
+        Set your <strong>classic personal access token</strong> here. Create
+        your classic personal access token under
+        <strong> Developer Settings</strong> in your GitHub account.
+      </Typography>
+      <Typography variant="body1" textAlign="left">
+        Make sure to provide it the <strong>repo</strong> permissions and
+        <strong> authorize with SSO</strong> for any private repos.
       </Typography>
       <Link
         target="_blank" // new tab
@@ -24,10 +29,10 @@ export default function AccessTokenSetting() {
         variant="body1"
         href="https://docs.github.com/en/enterprise-server@3.12/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token"
       >
-        Click here for more information
+        Click here for more info on creating your personal access token
       </Link>
       <TextField
-        label="Personal Access Token"
+        label="Classic Personal Access Token"
         helperText="ghp_"
         variant="standard"
         value={token}

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -58,7 +58,6 @@ export function useGetPullRequests() {
         setLoading(true);
 
         const savedToken = await getToken();
-        console.log("settign token", token);
         const client = new GitHubClient(savedToken);
         setToken(savedToken);
 

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -49,6 +49,7 @@ export function useGetPullRequests() {
   const [username, setUsername] = useState("");
   const [data, setData] = useState<RepoData[] | null>(null);
   const [loading, setLoading] = useState(true);
+  const [token, setToken] = useState<string | undefined>();
   // const [error, setError] = useState(false); // TODO display error
 
   useEffect(() => {
@@ -56,8 +57,10 @@ export function useGetPullRequests() {
       try {
         setLoading(true);
 
-        const token = await getToken();
-        const client = new GitHubClient(token);
+        const savedToken = await getToken();
+        console.log("settign token", token);
+        const client = new GitHubClient(savedToken);
+        setToken(savedToken);
 
         // Fetch data
         const storageRepos = await getRepositories();
@@ -94,5 +97,5 @@ export function useGetPullRequests() {
     });
   }, []);
 
-  return { username, data, loading };
+  return { username, data, loading, token };
 }


### PR DESCRIPTION
### Summary

In this PR, more clear instructions on how to set your personal access token has been added.

Previously, I have noticed that most people aren't guided to set this token after installing. When first opening the popup, the PR display page will now check if the token has been set in storage, and if it hasn't it will display an informational prompt noting that the user has not done this yet and direct them to the settings page.

### Changes
- Info messages when personal access token and repos aren't configured
- "Classic" has been added in front of all locations where personal access token is mentioned
- Bold text on settings page to indicate some keywords should the user skim through the instructions

### Screenshots
<details><summary>Info prompts</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/81d30b41-08fe-4522-83c5-3e6a227943e0)


</p>
</details> 

<details><summary>Bold texting and classic wording</summary>
<p>


![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/14bb9a7f-20c3-4404-817d-58323c94ad87)

</p>
</details> 