### PR TITLE
Snackbar / Toast messages on Repos page

### DIFF
--- a/src/popup/components/RepoOptions/components/Add/index.tsx
+++ b/src/popup/components/RepoOptions/components/Add/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Snackbar from "@mui/material/Snackbar";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
@@ -18,6 +19,8 @@ export default function Add({ onSave }: AddProps) {
   const [repository, setRepository] = useState("");
   const [rawJiraTags, setRawJiraTags] = useState("");
   const [jiraDomain, setJiraDomain] = useState("");
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
 
   const saveEnabled1 =
     repository !== "" && rawJiraTags === "" && jiraDomain === ""; // only repository field
@@ -91,17 +94,37 @@ export default function Add({ onSave }: AddProps) {
               rawJiraTags.length > 0 ? rawJiraTags.split(",") : undefined;
             const jiraDomainSanizited =
               jiraDomain.length > 0 ? jiraDomain : undefined;
-            onSave(repository, jiraTagsSanizited, jiraDomainSanizited).catch(
-              (e) => {
+            onSave(repository, jiraTagsSanizited, jiraDomainSanizited)
+              .then(() => {
+                setSnackbarMessage("Repository has been added/updated!");
+                setSnackbarOpen(true);
+              })
+              .catch((e) => {
+                setSnackbarMessage("Failed to add or update repository.");
+                setSnackbarOpen(true);
                 console.error(
                   `failed to save repo ${repository}, ${jiraDomain}, ${rawJiraTags}`,
                   e
                 );
-              }
-            );
+              });
           }}
         />
       </Stack>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        open={snackbarOpen}
+        onClose={() => {
+          setSnackbarOpen(false);
+          setSnackbarMessage("");
+        }}
+        key="bottomleft"
+        sx={{
+          width: "fit-content",
+          borderRadius: 10,
+        }}
+        autoHideDuration={2000}
+        message={snackbarMessage}
+      />
     </Stack>
   );
 }

--- a/src/popup/components/RepoOptions/components/Saved/index.tsx
+++ b/src/popup/components/RepoOptions/components/Saved/index.tsx
@@ -1,7 +1,8 @@
 import CircularProgress from "@mui/material/CircularProgress";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import React, { useState } from "react";
+import Snackbar from "@mui/material/Snackbar";
 import SavedRepo, { type SavedRepoProps } from "./SavedRepo";
 import { type ConfiguredRepo } from "../../../../../data/extension";
 
@@ -13,6 +14,9 @@ interface SavedProps {
 }
 
 export default function Saved({ repos, loading, error, onRemove }: SavedProps) {
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+
   return (
     <Stack width="100%" spacing={1}>
       {loading && (
@@ -34,12 +38,34 @@ export default function Saved({ repos, loading, error, onRemove }: SavedProps) {
           key={repo.url}
           repo={repo}
           onRemove={async () => {
-            onRemove(repo).catch((e) => {
-              console.error(`failed to remove repo`, repo, e);
-            });
+            onRemove(repo)
+              .then(() => {
+                setSnackbarMessage(`Removed ${repo.url} successfully!`);
+                setSnackbarOpen(true);
+              })
+              .catch((e) => {
+                setSnackbarMessage(`Failed to remove ${repo.url}.`);
+                setSnackbarOpen(true);
+                console.error(`failed to remove repo`, repo, e);
+              });
           }}
         />
       ))}
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        open={snackbarOpen}
+        onClose={() => {
+          setSnackbarOpen(false);
+          setSnackbarMessage("");
+        }}
+        key="bottomleft"
+        sx={{
+          width: "fit-content",
+          borderRadius: 10,
+        }}
+        autoHideDuration={2000}
+        message={snackbarMessage}
+      />
     </Stack>
   );
 }


### PR DESCRIPTION
### Summary

In this PR, the Repos page now has snackbar / toast messages that are displayed when attempting to save or delete a repo. This should help with the feedback when the user interacts with this page.

### Changes
- Added the snackbar components to the Repos page

### Screenshots

Click to see screenshots

<details><summary>Saving</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/011f27d5-8a39-4d7e-abed-2fa88702bf0e)

</p>
</details> 

<details><summary>Deleting</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/d57a8e88-3754-401f-9996-ff46e60837a3)=

</p>
</details> 