### PR TITLE
Feature: User configuration for behavior on clicking repo title

### DIFF
--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -29,7 +29,7 @@ export interface ConfiguredRepo {
   jiraTags?: string[];
 }
 
-export type BlankSpaceBehavior = "expand" | "link" | undefined;
+export type HeaderClickBehavior = "expand" | "link";
 
 /**
  * The data that represents what is stored for this extension in
@@ -43,7 +43,7 @@ export interface Storage {
   /** The current state of the user configured filters */
   filters: Filters;
   /** User setting to open section or go to repo when clicking blank space on the repo header */
-  blankSpaceBehavior?: BlankSpaceBehavior;
+  blankSpaceBehavior?: HeaderClickBehavior;
 }
 
 /**
@@ -217,8 +217,9 @@ export async function getFilterOptions() {
 /**
  * Returns whether or not the user wants to expand the repo section
  * or wants to open the repo in a new tab
+ * @returns "expand" or "link", defaults to expand if not previously saved
  */
-export async function getBlankSpaceBehavior(): Promise<BlankSpaceBehavior> {
+export async function getHeaderClickBehavior(): Promise<HeaderClickBehavior> {
   const storage = await getStorage();
   if (storage.blankSpaceBehavior === undefined) {
     storage.blankSpaceBehavior = "expand";
@@ -230,8 +231,8 @@ export async function getBlankSpaceBehavior(): Promise<BlankSpaceBehavior> {
  * Sets the configuration on whether or not the user wants to expand the repo section
  * or wants to open the repo in a new tab
  */
-export async function setBlankSpaceBehaviorSetting(
-  behavior: BlankSpaceBehavior
+export async function saveHeaderClickBehavior(
+  behavior: HeaderClickBehavior
 ): Promise<void> {
   const storage = await getStorage();
   storage.blankSpaceBehavior = behavior;

--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -29,7 +29,7 @@ export interface ConfiguredRepo {
   jiraTags?: string[];
 }
 
-export type BlankSpaceBehavior = "expand" | "link";
+export type BlankSpaceBehavior = "expand" | "link" | undefined;
 
 /**
  * The data that represents what is stored for this extension in
@@ -230,9 +230,10 @@ export async function getBlankSpaceBehavior(): Promise<BlankSpaceBehavior> {
  * Sets the configuration on whether or not the user wants to expand the repo section
  * or wants to open the repo in a new tab
  */
-export async function setBlankSpaceBehavior(
+export async function setBlankSpaceBehaviorSetting(
   behavior: BlankSpaceBehavior
 ): Promise<void> {
   const storage = await getStorage();
   storage.blankSpaceBehavior = behavior;
+  await setStorage(storage);
 }

--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -29,6 +29,8 @@ export interface ConfiguredRepo {
   jiraTags?: string[];
 }
 
+export type BlankSpaceBehavior = "expand" | "link";
+
 /**
  * The data that represents what is stored for this extension in
  * the browser's synced storage
@@ -40,6 +42,8 @@ export interface Storage {
   token: string;
   /** The current state of the user configured filters */
   filters: Filters;
+  /** User setting to open section or go to repo when clicking blank space on the repo header */
+  blankSpaceBehavior?: BlankSpaceBehavior;
 }
 
 /**
@@ -208,4 +212,27 @@ export async function saveFilterOptions(filters: Filters) {
 export async function getFilterOptions() {
   const storage = await getStorage();
   return storage.filters;
+}
+
+/**
+ * Returns whether or not the user wants to expand the repo section
+ * or wants to open the repo in a new tab
+ */
+export async function getBlankSpaceBehavior(): Promise<BlankSpaceBehavior> {
+  const storage = await getStorage();
+  if (storage.blankSpaceBehavior === undefined) {
+    storage.blankSpaceBehavior = "expand";
+  }
+  return storage.blankSpaceBehavior;
+}
+
+/**
+ * Sets the configuration on whether or not the user wants to expand the repo section
+ * or wants to open the repo in a new tab
+ */
+export async function setBlankSpaceBehavior(
+  behavior: BlankSpaceBehavior
+): Promise<void> {
+  const storage = await getStorage();
+  storage.blankSpaceBehavior = behavior;
 }

--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -43,7 +43,7 @@ export interface Storage {
   /** The current state of the user configured filters */
   filters: Filters;
   /** User setting to open section or go to repo when clicking blank space on the repo header */
-  blankSpaceBehavior?: HeaderClickBehavior;
+  headerClickBehavior?: HeaderClickBehavior;
 }
 
 /**
@@ -221,10 +221,10 @@ export async function getFilterOptions() {
  */
 export async function getHeaderClickBehavior(): Promise<HeaderClickBehavior> {
   const storage = await getStorage();
-  if (storage.blankSpaceBehavior === undefined) {
-    storage.blankSpaceBehavior = "expand";
+  if (storage.headerClickBehavior === undefined) {
+    storage.headerClickBehavior = "expand";
   }
-  return storage.blankSpaceBehavior;
+  return storage.headerClickBehavior;
 }
 
 /**
@@ -235,6 +235,6 @@ export async function saveHeaderClickBehavior(
   behavior: HeaderClickBehavior
 ): Promise<void> {
   const storage = await getStorage();
-  storage.blankSpaceBehavior = behavior;
+  storage.headerClickBehavior = behavior;
   await setStorage(storage);
 }

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -10,11 +10,13 @@ import { type RepoData } from "../../../../data";
 interface RepoTitleProps {
   /** The data of the repo to show for this section */
   repo: RepoData;
-  /** The function to execute to expand the header */
-  onExpand: React.MouseEventHandler<HTMLDivElement>;
+  /** The function to execute when click the expand button */
+  onExpand: React.MouseEventHandler;
 }
 
 export default function RepoHeader({ repo, onExpand }: RepoTitleProps) {
+  const option: number = 2;
+
   return (
     <Box
       sx={{
@@ -34,10 +36,10 @@ export default function RepoHeader({ repo, onExpand }: RepoTitleProps) {
           sx={{
             display: "flex",
             flexDirection: "row",
-            justifyContent: "flex-start",
-            gap: 1,
             overflow: "hidden",
             paddingX: 1,
+            bgcolor: "yellow",
+            flex: "initial",
           }}
           onClick={() => {
             createTab(repo.url).catch(() => {
@@ -64,17 +66,29 @@ export default function RepoHeader({ repo, onExpand }: RepoTitleProps) {
         disableInteractive
       >
         <Box
-          sx={{
-            flex: 1,
-            display: "flex",
-            flexDirection: "row",
-            justifyContent: "flex-end",
-          }}
+          sx={{ bgcolor: "blue", flex: 1 }}
           onClick={(e) => {
-            onExpand(e);
+            if (option === 1) {
+              createTab(repo.url).catch(() => {
+                console.error(`failed to create tab with url: ${repo.url}`);
+              });
+            }
+            if (option === 2) {
+              onExpand(e);
+            }
           }}
-        >
+        />
+      </Tooltip>
+      <Tooltip
+        title={`${repo.pullRequests.length} open`}
+        followCursor
+        disableInteractive
+      >
+        <Box sx={{ flex: 0 }}>
           <IconButton
+            onClick={(e) => {
+              onExpand(e);
+            }}
             sx={{
               "&:hover": {
                 bgcolor: "transparent",

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -5,9 +5,8 @@ import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import {
-  type BlankSpaceBehavior,
+  type HeaderClickBehavior,
   createTab,
-  getBlankSpaceBehavior,
 } from "../../../../data/extension";
 import { type RepoData } from "../../../../data";
 
@@ -16,14 +15,30 @@ interface RepoTitleProps {
   repo: RepoData;
   /** The function to execute when click the expand button */
   onExpand: React.MouseEventHandler;
-  blankSpaceBehavior: BlankSpaceBehavior;
+  /** The user configured behavior when the blank space in the header is clicked */
+  headerClickBehavior: HeaderClickBehavior;
 }
 
 export default function RepoHeader({
   repo,
   onExpand,
-  blankSpaceBehavior,
+  headerClickBehavior,
 }: RepoTitleProps) {
+  let extraHeaderSpaceFunction;
+  let extraHeaderSpaceToolTip = ``;
+  if (headerClickBehavior === "expand") {
+    extraHeaderSpaceFunction = onExpand;
+    extraHeaderSpaceToolTip = `${repo.pullRequests.length} open`;
+  }
+  if (headerClickBehavior === "link") {
+    extraHeaderSpaceFunction = () => {
+      createTab(repo.url).catch(() => {
+        console.error(`failed to create tab with url: ${repo.url}`);
+      });
+    };
+    extraHeaderSpaceToolTip = `${repo.url}`;
+  }
+
   return (
     <Box
       sx={{
@@ -45,7 +60,6 @@ export default function RepoHeader({
             flexDirection: "row",
             overflow: "hidden",
             paddingX: 1,
-            bgcolor: "yellow",
             flex: "initial",
           }}
           onClick={() => {
@@ -67,24 +81,8 @@ export default function RepoHeader({
           </Typography>
         </Box>
       </Tooltip>
-      <Tooltip
-        title={`${repo.pullRequests.length} open`}
-        followCursor
-        disableInteractive
-      >
-        <Box
-          sx={{ bgcolor: "blue", flex: 1 }}
-          onClick={(e) => {
-            if (blankSpaceBehavior === "link") {
-              createTab(repo.url).catch(() => {
-                console.error(`failed to create tab with url: ${repo.url}`);
-              });
-            }
-            if (blankSpaceBehavior === "expand") {
-              onExpand(e);
-            }
-          }}
-        />
+      <Tooltip title={extraHeaderSpaceToolTip} followCursor disableInteractive>
+        <Box sx={{ flex: 1 }} onClick={extraHeaderSpaceFunction} />
       </Tooltip>
       <Tooltip
         title={`${repo.pullRequests.length} open`}

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -10,11 +10,11 @@ import { type RepoData } from "../../../../data";
 interface RepoTitleProps {
   /** The data of the repo to show for this section */
   repo: RepoData;
-  /** The function to execute when click the expand button */
-  onOpen: React.MouseEventHandler<HTMLButtonElement>;
+  /** The function to execute to expand the header */
+  onExpand: React.MouseEventHandler<HTMLDivElement>;
 }
 
-export default function RepoHeader({ repo, onOpen: onExpand }: RepoTitleProps) {
+export default function RepoHeader({ repo, onExpand }: RepoTitleProps) {
   return (
     <Box
       sx={{
@@ -34,11 +34,10 @@ export default function RepoHeader({ repo, onOpen: onExpand }: RepoTitleProps) {
           sx={{
             display: "flex",
             flexDirection: "row",
-            flex: 1,
             justifyContent: "flex-start",
             gap: 1,
             overflow: "hidden",
-            paddingLeft: 1,
+            paddingX: 1,
           }}
           onClick={() => {
             createTab(repo.url).catch(() => {
@@ -66,13 +65,16 @@ export default function RepoHeader({ repo, onOpen: onExpand }: RepoTitleProps) {
       >
         <Box
           sx={{
-            flex: 0,
+            flex: 1,
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "flex-end",
+          }}
+          onClick={(e) => {
+            onExpand(e);
           }}
         >
           <IconButton
-            onClick={(e) => {
-              onExpand(e);
-            }}
             sx={{
               "&:hover": {
                 bgcolor: "transparent",

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -4,7 +4,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { createTab } from "../../../../data/extension";
+import {
+  type BlankSpaceBehavior,
+  createTab,
+  getBlankSpaceBehavior,
+} from "../../../../data/extension";
 import { type RepoData } from "../../../../data";
 
 interface RepoTitleProps {
@@ -12,11 +16,14 @@ interface RepoTitleProps {
   repo: RepoData;
   /** The function to execute when click the expand button */
   onExpand: React.MouseEventHandler;
+  blankSpaceBehavior: BlankSpaceBehavior;
 }
 
-export default function RepoHeader({ repo, onExpand }: RepoTitleProps) {
-  const option: number = 2;
-
+export default function RepoHeader({
+  repo,
+  onExpand,
+  blankSpaceBehavior,
+}: RepoTitleProps) {
   return (
     <Box
       sx={{
@@ -68,12 +75,12 @@ export default function RepoHeader({ repo, onExpand }: RepoTitleProps) {
         <Box
           sx={{ bgcolor: "blue", flex: 1 }}
           onClick={(e) => {
-            if (option === 1) {
+            if (blankSpaceBehavior === "link") {
               createTab(repo.url).catch(() => {
                 console.error(`failed to create tab with url: ${repo.url}`);
               });
             }
-            if (option === 2) {
+            if (blankSpaceBehavior === "expand") {
               onExpand(e);
             }
           }}

--- a/src/popup/components/PRDisplay/RepoSection/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/index.tsx
@@ -4,13 +4,19 @@ import Stack from "@mui/material/Stack";
 import RepoHeader from "./RepoHeader";
 import { type RepoData } from "../../../../data";
 import Card from "../../Card/Card";
+import { type BlankSpaceBehavior } from "../../../../data/extension";
 
 interface RepoSectionProps extends React.PropsWithChildren {
   /** The data of the repo to show for this section */
   repo: RepoData;
+  blankSpaceBehavior: BlankSpaceBehavior;
 }
 
-export default function RepoSection({ repo, children }: RepoSectionProps) {
+export default function RepoSection({
+  repo,
+  children,
+  blankSpaceBehavior,
+}: RepoSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -39,6 +45,7 @@ export default function RepoSection({ repo, children }: RepoSectionProps) {
           onExpand={() => {
             setIsOpen(!isOpen);
           }}
+          blankSpaceBehavior={blankSpaceBehavior}
         />
       </Stack>
       <Stack width="100%" bgcolor="white" borderRadius="inherit">

--- a/src/popup/components/PRDisplay/RepoSection/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/index.tsx
@@ -4,18 +4,18 @@ import Stack from "@mui/material/Stack";
 import RepoHeader from "./RepoHeader";
 import { type RepoData } from "../../../../data";
 import Card from "../../Card/Card";
-import { type BlankSpaceBehavior } from "../../../../data/extension";
+import { type HeaderClickBehavior } from "../../../../data/extension";
 
 interface RepoSectionProps extends React.PropsWithChildren {
   /** The data of the repo to show for this section */
   repo: RepoData;
-  blankSpaceBehavior: BlankSpaceBehavior;
+  headerClickBehavior: HeaderClickBehavior;
 }
 
 export default function RepoSection({
   repo,
   children,
-  blankSpaceBehavior,
+  headerClickBehavior,
 }: RepoSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -45,7 +45,7 @@ export default function RepoSection({
           onExpand={() => {
             setIsOpen(!isOpen);
           }}
-          blankSpaceBehavior={blankSpaceBehavior}
+          headerClickBehavior={headerClickBehavior}
         />
       </Stack>
       <Stack width="100%" bgcolor="white" borderRadius="inherit">

--- a/src/popup/components/PRDisplay/RepoSection/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/index.tsx
@@ -36,7 +36,7 @@ export default function RepoSection({ repo, children }: RepoSectionProps) {
       >
         <RepoHeader
           repo={repo}
-          onOpen={() => {
+          onExpand={() => {
             setIsOpen(!isOpen);
           }}
         />

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -17,7 +17,7 @@ import {
 export default function PRDisplay() {
   const { loadingFilters, filters, setFilters } = useSavedFilters();
   const { loading, data, username, token } = useGetPullRequests();
-  const blankSpaceBehavior = useGetBlankSpaceBehavior();
+  const [blankSpaceBehavior] = useGetBlankSpaceBehavior();
 
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -9,7 +9,7 @@ import NoPullRequest from "./RepoSection/NoPullRequest";
 import FilterOptions from "./Filters/Filters";
 import Card from "../Card/Card";
 import {
-  useGetBlankSpaceBehavior,
+  useGetHeaderClickBehavior,
   useGetPullRequests,
   useSavedFilters,
 } from "../../hooks";
@@ -17,7 +17,7 @@ import {
 export default function PRDisplay() {
   const { loadingFilters, filters, setFilters } = useSavedFilters();
   const { loading, data, username, token } = useGetPullRequests();
-  const [blankSpaceBehavior] = useGetBlankSpaceBehavior();
+  const [headerClickBehavior] = useGetHeaderClickBehavior();
 
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
@@ -74,7 +74,7 @@ export default function PRDisplay() {
               <RepoSection
                 key={repo.url}
                 repo={repo}
-                blankSpaceBehavior={blankSpaceBehavior}
+                headerClickBehavior={headerClickBehavior}
               >
                 {filtered.length > 0
                   ? filtered.map((pr) => (

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -8,11 +8,16 @@ import PullRequest from "./RepoSection/PullRequest";
 import NoPullRequest from "./RepoSection/NoPullRequest";
 import FilterOptions from "./Filters/Filters";
 import Card from "../Card/Card";
-import { useGetPullRequests, useSavedFilters } from "../../hooks";
+import {
+  useGetBlankSpaceBehavior,
+  useGetPullRequests,
+  useSavedFilters,
+} from "../../hooks";
 
 export default function PRDisplay() {
   const { loadingFilters, filters, setFilters } = useSavedFilters();
   const { loading, data, username, token } = useGetPullRequests();
+  const blankSpaceBehavior = useGetBlankSpaceBehavior();
 
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
@@ -66,7 +71,11 @@ export default function PRDisplay() {
             }
 
             return (
-              <RepoSection key={repo.url} repo={repo}>
+              <RepoSection
+                key={repo.url}
+                repo={repo}
+                blankSpaceBehavior={blankSpaceBehavior}
+              >
                 {filtered.length > 0
                   ? filtered.map((pr) => (
                       <PullRequest

--- a/src/popup/components/Settings/CustomUISettings.tsx
+++ b/src/popup/components/Settings/CustomUISettings.tsx
@@ -1,12 +1,10 @@
-import {
-  CircularProgress,
-  FormControl,
-  FormControlLabel,
-  Radio,
-  RadioGroup,
-  Stack,
-  Typography,
-} from "@mui/material";
+import CircularProgress from "@mui/material/CircularProgress";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
 import React from "react";
 import { useGetHeaderClickBehavior } from "../../hooks";
 import {

--- a/src/popup/components/Settings/CustomUISettings.tsx
+++ b/src/popup/components/Settings/CustomUISettings.tsx
@@ -1,0 +1,63 @@
+import {
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import React from "react";
+import { useGetBlankSpaceBehavior } from "../../hooks";
+import {
+  type BlankSpaceBehavior,
+  setBlankSpaceBehaviorSetting,
+} from "../../../data/extension";
+
+export default function CustomUISettings() {
+  const [blankSpaceBehavior, setBlankSpaceBehavior, loading] =
+    useGetBlankSpaceBehavior();
+
+  return (
+    <Stack direction="column" width="100%" padding={1}>
+      <Typography variant="body1" textAlign="left">
+        Select the behavior you wish to occur when you click on the empty space
+        between the repository name and the dropdown icon
+      </Typography>
+      <Stack>
+        {loading && (
+          <Stack sx={{ alignItems: "center", height: "42px" }}>
+            <CircularProgress />
+          </Stack>
+        )}
+        {!loading && (
+          <FormControl>
+            <RadioGroup
+              value={blankSpaceBehavior}
+              row
+              onChange={(e) => {
+                console.log(e.target.value);
+                setBlankSpaceBehavior(e.target.value as BlankSpaceBehavior);
+                setBlankSpaceBehaviorSetting(
+                  e.target.value as BlankSpaceBehavior
+                ).catch((error) => {
+                  console.error(
+                    "Failed to set the blank space behavior setting",
+                    error
+                  );
+                });
+              }}
+            >
+              <FormControlLabel
+                value="expand"
+                control={<Radio />}
+                label="Expand"
+              />
+              <FormControlLabel value="link" control={<Radio />} label="Link" />
+            </RadioGroup>
+          </FormControl>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/popup/components/Settings/CustomUISettings.tsx
+++ b/src/popup/components/Settings/CustomUISettings.tsx
@@ -8,21 +8,21 @@ import {
   Typography,
 } from "@mui/material";
 import React from "react";
-import { useGetBlankSpaceBehavior } from "../../hooks";
+import { useGetHeaderClickBehavior } from "../../hooks";
 import {
-  type BlankSpaceBehavior,
-  setBlankSpaceBehaviorSetting,
+  type HeaderClickBehavior,
+  saveHeaderClickBehavior,
 } from "../../../data/extension";
 
 export default function CustomUISettings() {
   const [blankSpaceBehavior, setBlankSpaceBehavior, loading] =
-    useGetBlankSpaceBehavior();
+    useGetHeaderClickBehavior();
 
   return (
     <Stack direction="column" width="100%" padding={1}>
       <Typography variant="body1" textAlign="left">
-        Select the behavior you wish to occur when you click on the empty space
-        between the repository name and the dropdown icon
+        The behavior when click the extra space between repo name and the
+        dropdown button
       </Typography>
       <Stack>
         {loading && (
@@ -37,9 +37,9 @@ export default function CustomUISettings() {
               row
               onChange={(e) => {
                 console.log(e.target.value);
-                setBlankSpaceBehavior(e.target.value as BlankSpaceBehavior);
-                setBlankSpaceBehaviorSetting(
-                  e.target.value as BlankSpaceBehavior
+                setBlankSpaceBehavior(e.target.value as HeaderClickBehavior);
+                saveHeaderClickBehavior(
+                  e.target.value as HeaderClickBehavior
                 ).catch((error) => {
                   console.error(
                     "Failed to set the blank space behavior setting",

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Stack from "@mui/material/Stack";
 import Card from "../Card/Card";
 import ResetStorageSetting from "./ResetStorageSetting";
+import CustomUISettings from "./CustomUISettings";
 import AccessTokenSetting from "./AccessTokenSetting";
 
 export default function Settings() {
@@ -12,6 +13,9 @@ export default function Settings() {
       </Card>
       <Card>
         <ResetStorageSetting />
+      </Card>
+      <Card>
+        <CustomUISettings />
       </Card>
     </Stack>
   );

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -5,6 +5,8 @@ import {
   getRepositories,
   getToken,
   setBadge,
+  getBlankSpaceBehavior,
+  type BlankSpaceBehavior,
 } from "../data/extension";
 import GitHubClient, { type RepoData } from "../data";
 
@@ -97,4 +99,24 @@ export function useGetPullRequests() {
   }, []);
 
   return { username, data, loading, token };
+}
+
+/**
+ * A hook to fetch the user's configuration for the Blank Space Setting
+ * @returns Returns a loading state variable, the data, and the username
+ */
+export function useGetBlankSpaceBehavior() {
+  const [blankSpaceBehavior, setBlankSpaceBehavior] =
+    useState<BlankSpaceBehavior>("expand");
+  useEffect(() => {
+    async function getBehavior() {
+      const behavior = await getBlankSpaceBehavior();
+      setBlankSpaceBehavior(behavior);
+    }
+    getBehavior().catch((e) => {
+      console.error("Failed to fetch blank space behavior", e);
+    });
+  }, []);
+
+  return blankSpaceBehavior;
 }

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -108,15 +108,21 @@ export function useGetPullRequests() {
 export function useGetBlankSpaceBehavior() {
   const [blankSpaceBehavior, setBlankSpaceBehavior] =
     useState<BlankSpaceBehavior>("expand");
+  const [loading, setLoading] = useState(true);
   useEffect(() => {
     async function getBehavior() {
       const behavior = await getBlankSpaceBehavior();
+      // eslint-disable-next-line no-promise-executor-return
       setBlankSpaceBehavior(behavior);
     }
-    getBehavior().catch((e) => {
-      console.error("Failed to fetch blank space behavior", e);
-    });
+    getBehavior()
+      .catch((e) => {
+        console.error("Failed to fetch blank space behavior", e);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, []);
 
-  return blankSpaceBehavior;
+  return [blankSpaceBehavior, setBlankSpaceBehavior, loading] as const;
 }

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -5,8 +5,8 @@ import {
   getRepositories,
   getToken,
   setBadge,
-  getBlankSpaceBehavior,
-  type BlankSpaceBehavior,
+  getHeaderClickBehavior,
+  type HeaderClickBehavior,
 } from "../data/extension";
 import GitHubClient, { type RepoData } from "../data";
 
@@ -105,24 +105,23 @@ export function useGetPullRequests() {
  * A hook to fetch the user's configuration for the Blank Space Setting
  * @returns Returns a loading state variable, the data, and the username
  */
-export function useGetBlankSpaceBehavior() {
-  const [blankSpaceBehavior, setBlankSpaceBehavior] =
-    useState<BlankSpaceBehavior>("expand");
+export function useGetHeaderClickBehavior() {
+  const [headerClickBehavior, setHeaderClickBehavior] =
+    useState<HeaderClickBehavior>("expand");
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     async function getBehavior() {
-      const behavior = await getBlankSpaceBehavior();
-      // eslint-disable-next-line no-promise-executor-return
-      setBlankSpaceBehavior(behavior);
+      const behavior = await getHeaderClickBehavior();
+      setHeaderClickBehavior(behavior);
     }
     getBehavior()
       .catch((e) => {
-        console.error("Failed to fetch blank space behavior", e);
+        console.error("Failed to fetch header space behavior", e);
       })
       .finally(() => {
         setLoading(false);
       });
   }, []);
 
-  return [blankSpaceBehavior, setBlankSpaceBehavior, loading] as const;
+  return [headerClickBehavior, setHeaderClickBehavior, loading] as const;
 }

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -11,7 +11,7 @@ import RepoOptions from "./components/RepoOptions";
 type Page = "PR" | "Repos" | "Settings";
 
 function Popup() {
-  const [page, setPage] = useState<Page>("PR");
+  const [page, setPage] = useState<Page>("Settings");
 
   return (
     <Stack

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -11,7 +11,7 @@ import RepoOptions from "./components/RepoOptions";
 type Page = "PR" | "Repos" | "Settings";
 
 function Popup() {
-  const [page, setPage] = useState<Page>("Settings");
+  const [page, setPage] = useState<Page>("PR");
 
   return (
     <Stack


### PR DESCRIPTION
### Summary

In this PR, a new user configuration setting is available on the settings page. The new setting allows the user to pick the behavior they wish to happen when clicking the empty space in between the name of the repo and the dropdown icon for each repository section.

Previously it would just link you to the repo, but some people preferred to be able to expand the section instead. This is the compromise that I came up with that lets the user choose. If there is an error in fetching the settings, it will default to expanding.

### Changes
- New settings section to set the header click behavior value
- New extension functions to handle getting and setting this header click behavior value
- New hook in React created to fetch this value on the popup

### Screenshots / Gifs

<details><summary>Click to see gifs</summary>
<p>

![Recording 2024-04-28 at 20 55 20](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/bdcf97d3-5894-426d-8ecc-90d7aa44610e)

</p>
</details> 


