### PR TITLE
Feature: Animated Expand Setting

### DIFF
--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -44,6 +44,8 @@ export interface Storage {
   filters: Filters;
   /** User setting to open section or go to repo when clicking blank space on the repo header */
   headerClickBehavior?: HeaderClickBehavior;
+  /** User setting to animate the expansion of a repo section or not */
+  animatedExpandSetting?: boolean;
 }
 
 /**
@@ -236,5 +238,30 @@ export async function saveHeaderClickBehavior(
 ): Promise<void> {
   const storage = await getStorage();
   storage.headerClickBehavior = behavior;
+  await setStorage(storage);
+}
+
+/**
+ * Gets the user's current configuration for if they want animated expansions or not
+ * @returns true if the user has set this configuration to be on, or false otherwise
+ */
+export async function getAnimatedExpandSetting(): Promise<boolean> {
+  const storage = await getStorage();
+  // default to false if not previously saved
+  if (storage.animatedExpandSetting === undefined) {
+    storage.animatedExpandSetting = false;
+  }
+  return storage.animatedExpandSetting;
+}
+
+/**
+ * Saves the value that the user wants to set the animated expansion setting to
+ * @param animatedExpandSetting {boolean} - the value of the animated expansion setting
+ */
+export async function saveAnimatedExpandSetting(
+  animatedExpandSetting: boolean
+): Promise<void> {
+  const storage = await getStorage();
+  storage.animatedExpandSetting = animatedExpandSetting;
   await setStorage(storage);
 }

--- a/src/popup/components/PRDisplay/RepoSection/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/index.tsx
@@ -10,12 +10,14 @@ interface RepoSectionProps extends React.PropsWithChildren {
   /** The data of the repo to show for this section */
   repo: RepoData;
   headerClickBehavior: HeaderClickBehavior;
+  animatedExpandSetting: boolean;
 }
 
 export default function RepoSection({
   repo,
   children,
   headerClickBehavior,
+  animatedExpandSetting,
 }: RepoSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -49,12 +51,20 @@ export default function RepoSection({
         />
       </Stack>
       <Stack width="100%" bgcolor="white" borderRadius="inherit">
-        <Collapse in={isOpen} timeout={500}>
+        {animatedExpandSetting && (
+          <Collapse in={isOpen} timeout={500}>
+            <Stack width="100%" spacing={0}>
+              {/* Children here are intended to be the pull request components */}
+              {children}
+            </Stack>
+          </Collapse>
+        )}
+        {!animatedExpandSetting && (
           <Stack width="100%" spacing={0}>
             {/* Children here are intended to be the pull request components */}
-            {children}
+            {isOpen && children}
           </Stack>
-        </Collapse>
+        )}
       </Stack>
     </Card>
   );

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -9,6 +9,7 @@ import NoPullRequest from "./RepoSection/NoPullRequest";
 import FilterOptions from "./Filters/Filters";
 import Card from "../Card/Card";
 import {
+  useGetAnimatedExpandSetting,
   useGetHeaderClickBehavior,
   useGetPullRequests,
   useSavedFilters,
@@ -18,6 +19,7 @@ export default function PRDisplay() {
   const { loadingFilters, filters, setFilters } = useSavedFilters();
   const { loading, data, username, token } = useGetPullRequests();
   const [headerClickBehavior] = useGetHeaderClickBehavior();
+  const [animatedExpandSetting] = useGetAnimatedExpandSetting();
 
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
@@ -75,6 +77,7 @@ export default function PRDisplay() {
                 key={repo.url}
                 repo={repo}
                 headerClickBehavior={headerClickBehavior}
+                animatedExpandSetting={animatedExpandSetting}
               >
                 {filtered.length > 0
                   ? filtered.map((pr) => (

--- a/src/popup/components/Settings/AnimatedExpandSettingCard.tsx
+++ b/src/popup/components/Settings/AnimatedExpandSettingCard.tsx
@@ -1,0 +1,56 @@
+import { Stack, Typography, CircularProgress, Switch } from "@mui/material";
+import React from "react";
+import { saveAnimatedExpandSetting } from "../../../data/extension";
+import { useGetAnimatedExpandSetting } from "../../hooks";
+import Card from "../Card/Card";
+
+export default function AnimatedExpandSettingCard() {
+  const [
+    animatedExpandSetting,
+    setAnimatedExpandSetting,
+    animatedExpandLoading,
+  ] = useGetAnimatedExpandSetting();
+
+  return (
+    <Card sx={{ bgcolor: "white" }}>
+      <Stack
+        width="100%"
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        paddingX={1}
+      >
+        <Typography variant="body1" textAlign="left">
+          Animated expands for repo section
+        </Typography>
+        {animatedExpandLoading && (
+          <Stack sx={{ alignItems: "center", height: "42px" }}>
+            <CircularProgress />
+          </Stack>
+        )}
+        {!animatedExpandLoading && (
+          <Switch
+            checked={animatedExpandSetting}
+            onChange={(e) => {
+              setAnimatedExpandSetting(e.target.checked);
+              saveAnimatedExpandSetting(e.target.checked).catch((error) => {
+                console.error(
+                  "Failed to set the animated expand setting",
+                  error
+                );
+              });
+            }}
+            inputProps={{ "aria-label": "animated-expand-setting" }}
+          />
+        )}
+      </Stack>
+
+      <Stack padding={1}>
+        <Typography variant="body2">
+          Turn this on if you want the repository section to open with a smooth
+          transition. Note that there may be performance issues.
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/popup/components/Settings/CustomUISettings.tsx
+++ b/src/popup/components/Settings/CustomUISettings.tsx
@@ -6,15 +6,10 @@ import RadioGroup from "@mui/material/RadioGroup";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { Switch } from "@mui/material";
-import {
-  useGetAnimatedExpandSetting,
-  useGetHeaderClickBehavior,
-} from "../../hooks";
+import { useGetHeaderClickBehavior } from "../../hooks";
 import {
   type HeaderClickBehavior,
   saveHeaderClickBehavior,
-  saveAnimatedExpandSetting,
 } from "../../../data/extension";
 
 export default function CustomUISettings() {

--- a/src/popup/components/Settings/CustomUISettings.tsx
+++ b/src/popup/components/Settings/CustomUISettings.tsx
@@ -6,10 +6,15 @@ import RadioGroup from "@mui/material/RadioGroup";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React from "react";
-import { useGetHeaderClickBehavior } from "../../hooks";
+import { Switch } from "@mui/material";
+import {
+  useGetAnimatedExpandSetting,
+  useGetHeaderClickBehavior,
+} from "../../hooks";
 import {
   type HeaderClickBehavior,
   saveHeaderClickBehavior,
+  saveAnimatedExpandSetting,
 } from "../../../data/extension";
 
 export default function CustomUISettings() {
@@ -34,7 +39,6 @@ export default function CustomUISettings() {
               value={blankSpaceBehavior}
               row
               onChange={(e) => {
-                console.log(e.target.value);
                 setBlankSpaceBehavior(e.target.value as HeaderClickBehavior);
                 saveHeaderClickBehavior(
                   e.target.value as HeaderClickBehavior
@@ -45,13 +49,20 @@ export default function CustomUISettings() {
                   );
                 });
               }}
+              sx={{ display: "flex", flexDirection: "row" }}
             >
               <FormControlLabel
                 value="expand"
                 control={<Radio />}
                 label="Expand"
+                sx={{ flex: 1 }}
               />
-              <FormControlLabel value="link" control={<Radio />} label="Link" />
+              <FormControlLabel
+                value="link"
+                control={<Radio />}
+                label="Link"
+                sx={{ flex: 1 }}
+              />
             </RadioGroup>
           </FormControl>
         )}

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -4,18 +4,20 @@ import Card from "../Card/Card";
 import ResetStorageSetting from "./ResetStorageSetting";
 import CustomUISettings from "./CustomUISettings";
 import AccessTokenSetting from "./AccessTokenSetting";
+import AnimatedExpandSettingCard from "./AnimatedExpandSettingCard";
 
 export default function Settings() {
   return (
-    <Stack width="100%" padding={1} spacing={1}>
-      <Card>
+    <Stack width="100%" padding={1} spacing={1} bgcolor="whitesmoke">
+      <Card sx={{ bgcolor: "white" }}>
         <AccessTokenSetting />
       </Card>
-      <Card>
-        <ResetStorageSetting />
-      </Card>
-      <Card>
+      <Card sx={{ bgcolor: "white" }}>
         <CustomUISettings />
+      </Card>
+      <AnimatedExpandSettingCard />
+      <Card sx={{ bgcolor: "white" }}>
+        <ResetStorageSetting />
       </Card>
     </Stack>
   );

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -7,6 +7,7 @@ import {
   setBadge,
   getHeaderClickBehavior,
   type HeaderClickBehavior,
+  getAnimatedExpandSetting,
 } from "../data/extension";
 import GitHubClient, { type RepoData } from "../data";
 
@@ -103,7 +104,7 @@ export function useGetPullRequests() {
 
 /**
  * A hook to fetch the user's configuration for the Blank Space Setting
- * @returns Returns a loading state variable, the data, and the username
+ * @returns Returns a loading state variable and the setting value
  */
 export function useGetHeaderClickBehavior() {
   const [headerClickBehavior, setHeaderClickBehavior] =
@@ -124,4 +125,30 @@ export function useGetHeaderClickBehavior() {
   }, []);
 
   return [headerClickBehavior, setHeaderClickBehavior, loading] as const;
+}
+
+/**
+ * A hook to fetch the user's configuration for the Animated Expand Setting
+ * @returns Returns a loading state variable and the setting value
+ */
+export function useGetAnimatedExpandSetting() {
+  const [animatedExpandSetting, setAnimatedExpandSetting] =
+    useState<boolean>(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function getSetting() {
+      const setting = await getAnimatedExpandSetting();
+      setAnimatedExpandSetting(setting);
+    }
+    getSetting()
+      .catch((e) => {
+        console.error("Failed to fetch animated expand setting", e);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return [animatedExpandSetting, setAnimatedExpandSetting, loading] as const;
 }


### PR DESCRIPTION
### Summary

In this PR, a new setting has been added that the user can configure. Some people may run into the issue where the animation to open a repo section to view the PRs is not smooth or causing the scrollbars to glitch out during the animation. I didn't want to completely get rid of the animations since it looks smooth so I created a setting that is off by default.

If the user wants to allow for the animations, they can enable it in the settings.

### Changes
- Created a new settings card
- Created a new hook to fetch the settings value
- Created new extension methods to get and save the value to storage
- Setting value is used the RepoSection component to either allow for the Collapse component to be rendered or not allowing for animations

### Screenshots / GIFs

<details open><summary>Click to see GIF</summary>
<p>

![Untitled](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/4887c554-c860-42a8-b1b2-3bdd7d3149f2)

</p>
</details> 