### PR TITLE
Feature: Make Header Stick to the Top

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -2,7 +2,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import CssBaseline from "@mui/material/CssBaseline";
 import Stack from "@mui/material/Stack";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { render } from "react-dom";
 import PRDisplay from "./components/PRDisplay";
 import Settings from "./components/Settings";
@@ -12,6 +12,15 @@ type Page = "PR" | "Repos" | "Settings";
 
 function Popup() {
   const [page, setPage] = useState<Page>("PR");
+  const scrollRef = useRef<HTMLDivElement>();
+
+  function scrollToTop() {
+    if (scrollRef?.current != null) {
+      scrollRef.current.scrollTo({
+        top: 0,
+      });
+    }
+  }
 
   return (
     <Stack
@@ -46,6 +55,7 @@ function Popup() {
           disableRipple
           onClick={() => {
             setPage("PR");
+            scrollToTop();
           }}
         >
           PR
@@ -61,6 +71,7 @@ function Popup() {
           disableRipple
           onClick={() => {
             setPage("Repos");
+            scrollToTop();
           }}
         >
           Repos
@@ -76,12 +87,14 @@ function Popup() {
           disableRipple
           onClick={() => {
             setPage("Settings");
+            scrollToTop();
           }}
         >
           Settings
         </Button>
       </Box>
       <Box
+        ref={scrollRef}
         sx={{
           width: "100%",
           overflowY: "scroll",

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -22,18 +22,6 @@ function Popup() {
       sx={{
         width: "400px",
         maxHeight: "600px",
-        overflowY: "scroll",
-        "&::-webkit-scrollbar": {
-          width: 8,
-        },
-        "&::-webkit-scrollbar-track": {
-          background: "rgba(0, 0, 0, 0.1)",
-        },
-        "&::-webkit-scrollbar-thumb": {
-          background: "rgba(0, 0, 0, 0.4)",
-        },
-        scrollbarColor: "rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.1)",
-        scrollbarWidth: "thin",
       }}
     >
       <CssBaseline />
@@ -93,9 +81,27 @@ function Popup() {
           Settings
         </Button>
       </Box>
-      {page === "PR" && <PRDisplay />}
-      {page === "Repos" && <RepoOptions />}
-      {page === "Settings" && <Settings />}
+      <Box
+        sx={{
+          width: "100%",
+          overflowY: "scroll",
+          "&::-webkit-scrollbar": {
+            width: 8,
+          },
+          "&::-webkit-scrollbar-track": {
+            background: "rgba(0, 0, 0, 0.1)",
+          },
+          "&::-webkit-scrollbar-thumb": {
+            background: "rgba(0, 0, 0, 0.4)",
+          },
+          scrollbarColor: "rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.1)",
+          scrollbarWidth: "thin",
+        }}
+      >
+        {page === "PR" && <PRDisplay />}
+        {page === "Repos" && <RepoOptions />}
+        {page === "Settings" && <Settings />}
+      </Box>
     </Stack>
   );
 }


### PR DESCRIPTION
### Summary

When scrolling through one of the pages, if you want to navigate to another page, you will have to scroll back to the top to see the top bar for selecting a new page. This PR, makes the page header stick to the top so that you don't have to scroll back up in order to navigate.

### Changes
- `popup.jsx` root element now has a `<Box />` component that wraps around the page component
- Scrolling is now only contained to this new `<Box />` component, instead of including the page header components

### Screenshots / GIFs
<details open><summary>Click to see GIF</summary>
<p>

![Untitled](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/35a777d8-fc45-4d67-a244-067e5905329f)

</p>
</details> 