### PR TITLE
Feature: Review State on Pull Request Display

### DIFF
--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/ReviewIcons.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/ReviewIcons.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import DoneIcon from "@mui/icons-material/Done";
+import FeedbackOutlinedIcon from "@mui/icons-material/FeedbackOutlined";
+import ChatBubbleOutlineOutlinedIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
+import Tooltip from "@mui/material/Tooltip";
+
+export function ApprovedIcon() {
+  return (
+    <Tooltip
+      title="You have approved this pull request"
+      placement="top"
+      disableInteractive
+    >
+      <DoneIcon
+        sx={{
+          color: "#1f883d",
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export function ChangesRequestedIcon() {
+  return (
+    <Tooltip
+      title="You have requested changes on this pull request"
+      placement="top"
+      disableInteractive
+    >
+      <FeedbackOutlinedIcon
+        sx={{
+          color: "red",
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export function CommentedIcon() {
+  return (
+    <Tooltip
+      title="You have left comments on this pull request"
+      placement="top"
+      disableInteractive
+    >
+      <ChatBubbleOutlineOutlinedIcon
+        sx={{
+          color: "#767676",
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import DoneIcon from "@mui/icons-material/Done";
-import FeedbackOutlinedIcon from "@mui/icons-material/FeedbackOutlined";
-import ChatBubbleOutlineOutlinedIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
-import Tooltip from "@mui/material/Tooltip";
 import JiraIconButton from "./JiraIconButton";
 import GitHubIconButton from "./GitHubIconButton";
 import type { PullRequestData } from "../../../../../data";

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
@@ -1,9 +1,18 @@
 import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import DoneIcon from "@mui/icons-material/Done";
+import FeedbackOutlinedIcon from "@mui/icons-material/FeedbackOutlined";
+import ChatBubbleOutlineOutlinedIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
+import Tooltip from "@mui/material/Tooltip";
 import JiraIconButton from "./JiraIconButton";
 import GitHubIconButton from "./GitHubIconButton";
 import type { PullRequestData } from "../../../../../data";
+import {
+  ApprovedIcon,
+  ChangesRequestedIcon,
+  CommentedIcon,
+} from "./ReviewIcons";
 
 interface PullRequestProps {
   pr: PullRequestData;
@@ -23,7 +32,7 @@ export default function PullRequest({
       direction="row"
       alignItems="center"
       spacing={1}
-      width="100%"
+      flex={1}
       sx={{
         "&:hover": { bgcolor: "whitesmoke" },
       }}
@@ -32,7 +41,7 @@ export default function PullRequest({
     >
       <GitHubIconButton pr={pr} />
       {isJiraConfigured && <JiraIconButton jiraUrl={pr.jiraUrl} />}
-      <Stack overflow="hidden">
+      <Stack overflow="hidden" flex={1}>
         <Typography variant="caption" fontStyle="italic">
           {pr.username}
         </Typography>
@@ -48,6 +57,21 @@ export default function PullRequest({
           {pr.title}
         </Typography>
       </Stack>
+
+      {/* Icons to track if the user reviewed the pull request  */}
+      {pr.viewerLatestReview !== null && (
+        <Stack
+          sx={{
+            justifySelf: "flex-end",
+          }}
+        >
+          {pr.viewerLatestReview === "APPROVED" && <ApprovedIcon />}
+          {pr.viewerLatestReview === "CHANGES_REQUESTED" && (
+            <ChangesRequestedIcon />
+          )}
+          {pr.viewerLatestReview === "COMMENTED" && <CommentedIcon />}
+        </Stack>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
### Summary

In this PR, the user will now be able to see what pull requests they have recently reviewed. The latest review given by the user is fetched from the GitHub API on each pull request, and based on the type of review they gave, a different icon will be presented.

The currently supported review states that will show icons are for if the user left comments, requested changes, or approved it. It is important to note that the icons don't exactly match up with the icon's in GitHub but are close. To give some clarity, a tooltip will display explaining what the icon means.

### Changes
- Added a new Icons to the pull request component in the PRDisplay page

### Screenshots / GIFs

<details open><summary>Click to see screenshots</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/bb8ecc65-b1a6-4036-a55f-63067107733b)

</p>
</details> 

