### PR TITLE
Bugfix: Jira Button Now Links Properly

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -226,6 +226,7 @@ export default class GitHubClient {
         url: data.url,
         isJiraConfigured,
         pullRequests: data.pullRequests.nodes.map((node) => {
+          // Parse jira tickets if detected
           const ticketTags: ConfiguredRepo["jiraTags"] = [];
           configuredRepo?.jiraTags?.forEach((jiraTag) => {
             const regex = new RegExp(`${jiraTag}-\\d+`, "g");
@@ -241,8 +242,16 @@ export default class GitHubClient {
               ticketTags.push(...ticketsInBody);
             }
           });
+          let jiraUrl;
+          if (
+            configuredRepo?.jiraDomain !== undefined &&
+            ticketTags.length > 0
+          ) {
+            jiraUrl = `${configuredRepo.jiraDomain}/${ticketTags[0]}`;
+          }
+
           return {
-            jiraUrl: ticketTags[0],
+            jiraUrl,
             draft: node.isDraft,
             number: node.number,
             title: node.title,


### PR DESCRIPTION
### Summary

As part of the shift to GraphQL, one of the things that wasn't properly migrated was the parsing of the Jira tickets, where the ticket wasn't prepended with the configured jira domain. This has been fixed in this PR

### Changes
- Prepend the detected jira tickets with the Jira domain
