### PR TITLE
Feature: Status checks for each pull request

### DIFF
--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/ReviewIcons.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/ReviewIcons.tsx
@@ -12,6 +12,7 @@ export function ApprovedIcon() {
       disableInteractive
     >
       <DoneIcon
+        fontSize="small"
         sx={{
           color: "#1f883d",
         }}
@@ -28,6 +29,7 @@ export function ChangesRequestedIcon() {
       disableInteractive
     >
       <FeedbackOutlinedIcon
+        fontSize="small"
         sx={{
           color: "red",
         }}
@@ -44,6 +46,7 @@ export function CommentedIcon() {
       disableInteractive
     >
       <ChatBubbleOutlineOutlinedIcon
+        fontSize="small"
         sx={{
           color: "#767676",
         }}

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/StatusCheckIcons.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/StatusCheckIcons.tsx
@@ -15,6 +15,7 @@ export function PendingStatusChecksIcon() {
         sx={{
           color: "#DCAB08",
           fontSize: "10px",
+          cursor: "pointer",
         }}
       />
     </Tooltip>
@@ -28,6 +29,7 @@ export function SuccessStatusChecksIcon() {
         sx={{
           color: "#1f883d",
           fontSize: "16px",
+          cursor: "pointer",
         }}
       />
     </Tooltip>
@@ -41,6 +43,7 @@ export function FailedStatusChecksIcon() {
         sx={{
           color: "red",
           fontSize: "16px",
+          cursor: "pointer",
         }}
       />
     </Tooltip>

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/StatusCheckIcons.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/StatusCheckIcons.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import CircleIcon from "@mui/icons-material/Circle";
+import ClearIcon from "@mui/icons-material/Clear";
+import DoneIcon from "@mui/icons-material/Done";
+import Tooltip from "@mui/material/Tooltip";
+
+export function PendingStatusChecksIcon() {
+  return (
+    <Tooltip
+      title="Checks are still in rrogress"
+      placement="top"
+      disableInteractive
+    >
+      <CircleIcon
+        sx={{
+          color: "#DCAB08",
+          fontSize: "10px",
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export function SuccessStatusChecksIcon() {
+  return (
+    <Tooltip title="All checks passed" placement="top" disableInteractive>
+      <DoneIcon
+        sx={{
+          color: "#1f883d",
+          fontSize: "16px",
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+export function FailedStatusChecksIcon() {
+  return (
+    <Tooltip title="Checks have failed" placement="top" disableInteractive>
+      <ClearIcon
+        sx={{
+          color: "red",
+          fontSize: "16px",
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
@@ -9,6 +9,7 @@ import {
   ChangesRequestedIcon,
   CommentedIcon,
 } from "./ReviewIcons";
+import { SuccessStatusChecksIcon } from "./StatusCheckIcons";
 
 interface PullRequestProps {
   pr: PullRequestData;
@@ -38,9 +39,12 @@ export default function PullRequest({
       <GitHubIconButton pr={pr} />
       {isJiraConfigured && <JiraIconButton jiraUrl={pr.jiraUrl} />}
       <Stack overflow="hidden" flex={1}>
-        <Typography variant="caption" fontStyle="italic">
-          {pr.username}
-        </Typography>
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Typography variant="caption" fontStyle="italic">
+            {pr.username}
+          </Typography>
+          <SuccessStatusChecksIcon />
+        </Stack>
         <Typography
           variant="caption"
           sx={{

--- a/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/PullRequest/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
 import JiraIconButton from "./JiraIconButton";
 import GitHubIconButton from "./GitHubIconButton";
 import type { PullRequestData } from "../../../../../data";
@@ -9,7 +10,12 @@ import {
   ChangesRequestedIcon,
   CommentedIcon,
 } from "./ReviewIcons";
-import { SuccessStatusChecksIcon } from "./StatusCheckIcons";
+import {
+  FailedStatusChecksIcon,
+  PendingStatusChecksIcon,
+  SuccessStatusChecksIcon,
+} from "./StatusCheckIcons";
+import { createTab } from "../../../../../data/extension";
 
 interface PullRequestProps {
   pr: PullRequestData;
@@ -43,7 +49,17 @@ export default function PullRequest({
           <Typography variant="caption" fontStyle="italic">
             {pr.username}
           </Typography>
-          <SuccessStatusChecksIcon />
+          <Box
+            onClick={() => {
+              createTab(pr.checksUrl).catch(() => {
+                console.error(`Failed to create tab with url ${pr.checksUrl}`);
+              });
+            }}
+          >
+            {pr.checksState === "SUCCESS" && <SuccessStatusChecksIcon />}
+            {pr.checksState === "FAILURE" && <FailedStatusChecksIcon />}
+            {pr.checksState === "PENDING" && <PendingStatusChecksIcon />}
+          </Box>
         </Stack>
         <Typography
           variant="caption"


### PR DESCRIPTION
### Summary

In this PR, the status check reports have been added to be visible on each pull request.

There are a few things to note:
- The checks may not be completely accurate if the repository is configured with external 3rd party tools for adding checks on a pull request
- The checks icon will show the overall status of success, failed, pending, or if there aren't any configured
- At the moment the performance has taken a hit because the query for the API has become more complicated, this will be addressed before this feature is available for users

### Changes
- Updated query to fetch status checks information
- Parallelized the query to split up the complexity of the query over multiple calls
- Added new components to render icons next to the author on the pull request and clicking on them will navigate to the checks for the pull request

### Screenshots / GIFs
<details open><summary>Details</summary>
<p>

![image](https://github.com/syj67507/github-pr-chrome-extension/assets/33601740/56b91ba2-7bb5-4d50-86db-13070b92dd65)

</p>
</details> 

### Other changes
- Updated the icons for if the user has previously reviewed

### Other Notes
- This feature will probably be off by default and can be enabled in the settings page with a description that explains that these checks may not be completely accurate for the reasons mentioned above in the summary
- Performance will need to be enhanced to make this extension load more quickly, likely by making it fetch the pull requests for a given repository only when opening a repo section