### PR TITLE
Bugfix: Jira Ticket Resolves with `/browse` in the URL

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -337,7 +337,7 @@ export default class GitHubClient {
             configuredRepo?.jiraDomain !== undefined &&
             ticketTags.length > 0
           ) {
-            jiraUrl = `${configuredRepo.jiraDomain}/${ticketTags[0]}`;
+            jiraUrl = `${configuredRepo.jiraDomain}/browse/${ticketTags[0]}`;
           }
 
           // Determine checks state and conclusion


### PR DESCRIPTION
### Summary

An earlier PR to fix this issue didn't solve it completely. The domain needs to include `/browse` which was not put in earlier. This PR puts it in to fix that.

### Changes

- Added `/browse`