### PR TITLE
Feature: add badge with pr count for each pr

### DIFF
--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -46,6 +46,7 @@ export default function RepoHeader({
         display: "flex",
         flexDirection: "row",
         padding: 1,
+        alignItems: "center"
       }}
     >
       <Tooltip
@@ -60,8 +61,6 @@ export default function RepoHeader({
             flexDirection: "row",
             overflow: "hidden",
             paddingX: 1,
-            flex: 1,
-            minWidth: 0,
           }}
           onClick={() => {
             createTab(repo.url).catch(() => {
@@ -82,30 +81,38 @@ export default function RepoHeader({
           >
             {repo.name}
           </Typography>
-          {repo.pullRequests.length> 0 && (
+        </Box>
+      </Tooltip>
+      <Tooltip title={extraHeaderSpaceToolTip} followCursor disableInteractive>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "flex-end",
+            flex: 1,
+          }}
+          onClick={extraHeaderSpaceFunction}
+        >
+          {repo.pullRequests.length > 0 && (
             <Box
               sx={{
                 backgroundColor: "#2076d2",
                 borderRadius: "50%",
-                marginLeft: 1,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                padding: "0.25em",
-                aspectRatio: "1",
-                minWidth: "1.5em",
-                minHeight: "1.5em",
+                width: "2em",
+                height: "2em",
               }}
             >
-              <Typography variant="caption" sx={{ color: "white", fontWeight: "bold" }}>
+              <Typography
+                variant="caption"
+                sx={{ color: "white", fontWeight: "bold" }}
+              >
                 {repo.pullRequests.length}
               </Typography>
             </Box>
           )}
         </Box>
-      </Tooltip>
-      <Tooltip title={extraHeaderSpaceToolTip} followCursor disableInteractive>
-        <Box sx={{ flex: 0 }} onClick={extraHeaderSpaceFunction} />
       </Tooltip>
       <Tooltip
         title={`${repo.pullRequests.length} open`}

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -60,7 +60,8 @@ export default function RepoHeader({
             flexDirection: "row",
             overflow: "hidden",
             paddingX: 1,
-            flex: "initial",
+            flex: 1,
+            minWidth: 0,
           }}
           onClick={() => {
             createTab(repo.url).catch(() => {
@@ -75,14 +76,36 @@ export default function RepoHeader({
               overflow: "hidden",
               whiteSpace: "nowrap",
               textOverflow: "ellipsis",
+              flex: 1,
+              minWidth: 0,
             }}
           >
             {repo.name}
           </Typography>
+          {repo.pullRequests.length> 0 && (
+            <Box
+              sx={{
+                backgroundColor: "#2076d2",
+                borderRadius: "50%",
+                marginLeft: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "0.25em",
+                aspectRatio: "1",
+                minWidth: "1.5em",
+                minHeight: "1.5em",
+              }}
+            >
+              <Typography variant="caption" sx={{ color: "white", fontWeight: "bold" }}>
+                {repo.pullRequests.length}
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Tooltip>
       <Tooltip title={extraHeaderSpaceToolTip} followCursor disableInteractive>
-        <Box sx={{ flex: 1 }} onClick={extraHeaderSpaceFunction} />
+        <Box sx={{ flex: 0 }} onClick={extraHeaderSpaceFunction} />
       </Tooltip>
       <Tooltip
         title={`${repo.pullRequests.length} open`}


### PR DESCRIPTION
# Summary
This PR adds a badge next to each repository’s name, displaying the number of open pull requests for that repo. This provides a quick, at-a-glance indicator of which repos currently have PRs that need attention.

# Details

- Introduces a small, rounded badge showing the PR count.
- Leverages existing Material-UI components and styling for a consistent look and feel.
- Helps users quickly identify where to focus their attention without expanding each repo.

# Why This Change?
Previously, users had to expand each repository section to see if any PRs were open. By displaying the count right in the header, the UI becomes more informative and efficient.

## How it looked before
![image](https://github.com/user-attachments/assets/23999531-5eae-402a-a494-dc38aa123a46)

## How it looks after
![image](https://github.com/user-attachments/assets/f69b0de5-e1b2-4139-8dcd-a6668518e4cb)
