### PR TITLE
Feature: Configurable Repo Header Badge

### DIFF
--- a/src/data/extension.ts
+++ b/src/data/extension.ts
@@ -48,6 +48,8 @@ export interface Storage {
   animatedExpandSetting?: boolean;
   /** User setting to enable the status checks for each pull request */
   statusChecksSetting?: boolean;
+  /** User setting to enable a badge on the repo header for a repo section */
+  repoHeaderBadgeSetting?: boolean;
 }
 
 /**

--- a/src/data/extension/repoHeaderBadgeSetting.ts
+++ b/src/data/extension/repoHeaderBadgeSetting.ts
@@ -1,0 +1,27 @@
+import { getStorage, setStorage } from "../extension";
+
+/**
+ * Gets the user's current configuration for if they want to see a badge indicating how
+ * many pull requests are open for each repo
+ * @returns true if the user has set this configuration to be on, or false otherwise
+ */
+export async function getRepoHeaderBadgeSetting(): Promise<boolean> {
+  const storage = await getStorage();
+  // default to false if not previously saved
+  if (storage.repoHeaderBadgeSetting === undefined) {
+    storage.repoHeaderBadgeSetting = false;
+  }
+  return storage.repoHeaderBadgeSetting;
+}
+
+/**
+ * Saves the value that the user wants to set the repo header badge setting to
+ * @param repoHeaderBadgeSetting {boolean} - the value of the repo header badge setting
+ */
+export async function saveRepoHeaderBadgeSetting(
+  repoHeaderBadgeSetting: boolean
+): Promise<void> {
+  const storage = await getStorage();
+  storage.repoHeaderBadgeSetting = repoHeaderBadgeSetting;
+  await setStorage(storage);
+}

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import Box from "@mui/material/Box";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import IconButton from "@mui/material/IconButton";
@@ -17,12 +17,15 @@ interface RepoTitleProps {
   onExpand: React.MouseEventHandler;
   /** The user configured behavior when the blank space in the header is clicked */
   headerClickBehavior: HeaderClickBehavior;
+  /** The user configured setting for displaying a repo header badge for showing the number of pull requests */
+  repoHeaderBadgeSetting: boolean;
 }
 
 export default function RepoHeader({
   repo,
   onExpand,
   headerClickBehavior,
+  repoHeaderBadgeSetting,
 }: RepoTitleProps) {
   let extraHeaderSpaceFunction;
   let extraHeaderSpaceToolTip = ``;
@@ -39,6 +42,8 @@ export default function RepoHeader({
     extraHeaderSpaceToolTip = `${repo.url}`;
   }
 
+  const ref = useRef<HTMLDivElement>();
+
   return (
     <Box
       sx={{
@@ -46,7 +51,7 @@ export default function RepoHeader({
         display: "flex",
         flexDirection: "row",
         padding: 1,
-        alignItems: "center"
+        alignItems: "center",
       }}
     >
       <Tooltip
@@ -56,6 +61,7 @@ export default function RepoHeader({
         enterDelay={1000}
       >
         <Box
+          ref={ref}
           sx={{
             display: "flex",
             flexDirection: "row",
@@ -89,10 +95,11 @@ export default function RepoHeader({
             display: "flex",
             justifyContent: "flex-end",
             flex: 1,
+            height: "2em",
           }}
           onClick={extraHeaderSpaceFunction}
         >
-          {repo.pullRequests.length > 0 && (
+          {repoHeaderBadgeSetting && repo.pullRequests.length > 0 && (
             <Box
               sx={{
                 backgroundColor: "#2076d2",
@@ -101,7 +108,6 @@ export default function RepoHeader({
                 alignItems: "center",
                 justifyContent: "center",
                 width: "2em",
-                height: "2em",
               }}
             >
               <Typography

--- a/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/RepoHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React from "react";
 import Box from "@mui/material/Box";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import IconButton from "@mui/material/IconButton";
@@ -42,8 +42,6 @@ export default function RepoHeader({
     extraHeaderSpaceToolTip = `${repo.url}`;
   }
 
-  const ref = useRef<HTMLDivElement>();
-
   return (
     <Box
       sx={{
@@ -61,7 +59,6 @@ export default function RepoHeader({
         enterDelay={1000}
       >
         <Box
-          ref={ref}
           sx={{
             display: "flex",
             flexDirection: "row",

--- a/src/popup/components/PRDisplay/RepoSection/index.tsx
+++ b/src/popup/components/PRDisplay/RepoSection/index.tsx
@@ -11,6 +11,8 @@ interface RepoSectionProps extends React.PropsWithChildren {
   repo: RepoData;
   headerClickBehavior: HeaderClickBehavior;
   animatedExpandSetting: boolean;
+  /** The user's configured setting for the repo header badge */
+  repoHeaderBadgeSetting: boolean;
 }
 
 export default function RepoSection({
@@ -18,6 +20,7 @@ export default function RepoSection({
   children,
   headerClickBehavior,
   animatedExpandSetting,
+  repoHeaderBadgeSetting,
 }: RepoSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -48,6 +51,7 @@ export default function RepoSection({
             setIsOpen(!isOpen);
           }}
           headerClickBehavior={headerClickBehavior}
+          repoHeaderBadgeSetting={repoHeaderBadgeSetting}
         />
       </Stack>
       <Stack width="100%" bgcolor="white" borderRadius="inherit">

--- a/src/popup/components/PRDisplay/index.tsx
+++ b/src/popup/components/PRDisplay/index.tsx
@@ -12,6 +12,7 @@ import {
   useGetAnimatedExpandSetting,
   useGetHeaderClickBehavior,
   useGetPullRequests,
+  useGetRepoHeaderBadgeSetting,
   useGetStatusChecksSetting,
   useSavedFilters,
 } from "../../hooks";
@@ -22,6 +23,7 @@ export default function PRDisplay() {
   const [headerClickBehavior] = useGetHeaderClickBehavior();
   const [animatedExpandSetting] = useGetAnimatedExpandSetting();
   const [statusChecksSetting] = useGetStatusChecksSetting();
+  const [repoHeaderBadgeSetting] = useGetRepoHeaderBadgeSetting();
 
   return (
     <Stack width="100%" bgcolor="whitesmoke" padding={1} spacing={1}>
@@ -80,6 +82,7 @@ export default function PRDisplay() {
                 repo={repo}
                 headerClickBehavior={headerClickBehavior}
                 animatedExpandSetting={animatedExpandSetting}
+                repoHeaderBadgeSetting={repoHeaderBadgeSetting}
               >
                 {filtered.length > 0
                   ? filtered.map((pr) => (

--- a/src/popup/components/Settings/RepoHeaderBadgeSetting.tsx
+++ b/src/popup/components/Settings/RepoHeaderBadgeSetting.tsx
@@ -1,0 +1,61 @@
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import CircularProgress from "@mui/material/CircularProgress";
+import Switch from "@mui/material/Switch";
+import React from "react";
+import { useGetRepoHeaderBadgeSetting } from "../../hooks";
+import Card from "../Card/Card";
+import { saveRepoHeaderBadgeSetting } from "../../../data/extension/repoHeaderBadgeSetting";
+
+export default function RepoHeaderBadgeSettingCard() {
+  const [
+    repoHeaderBadgeSetting,
+    setRepoHeaderBadgeSetting,
+    repoHeaderBadgeSettingLoading,
+  ] = useGetRepoHeaderBadgeSetting();
+
+  return (
+    <Card sx={{ bgcolor: "white" }}>
+      <Stack
+        width="100%"
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        paddingX={1}
+      >
+        <Typography variant="body2" textAlign="left">
+          Repository Header Badge
+        </Typography>
+        {repoHeaderBadgeSettingLoading && (
+          <Stack sx={{ alignItems: "center", height: "42px" }}>
+            <CircularProgress />
+          </Stack>
+        )}
+        {!repoHeaderBadgeSettingLoading && (
+          <Switch
+            checked={repoHeaderBadgeSetting}
+            onChange={(e) => {
+              setRepoHeaderBadgeSetting(e.target.checked);
+              saveRepoHeaderBadgeSetting(e.target.checked).catch(
+                (error: any) => {
+                  console.error(
+                    "Failed to set the repo header badge setting",
+                    error
+                  );
+                }
+              );
+            }}
+            inputProps={{ "aria-label": "status-check-setting" }}
+          />
+        )}
+      </Stack>
+
+      <Stack padding={1}>
+        <Typography variant="caption">
+          Turn this on if you want to see a badge that indicates how many pull
+          requests are open for each repository in the header
+        </Typography>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/popup/components/Settings/RepoHeaderBadgeSettingCard.tsx
+++ b/src/popup/components/Settings/RepoHeaderBadgeSettingCard.tsx
@@ -45,7 +45,7 @@ export default function RepoHeaderBadgeSettingCard() {
                 }
               );
             }}
-            inputProps={{ "aria-label": "status-check-setting" }}
+            inputProps={{ "aria-label": "repo-header-badge-setting" }}
           />
         )}
       </Stack>

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -5,7 +5,7 @@ import HeaderClickSetting from "./HeaderClickSetting";
 import AccessTokenSetting from "./AccessTokenSetting";
 import AnimatedExpandSettingCard from "./AnimatedExpandSettingCard";
 import StatusChecksSettingCard from "./StatusChecksSetting";
-import RepoHeaderBadgeSettingCard from "./RepoHeaderBadgeSetting";
+import RepoHeaderBadgeSettingCard from "./RepoHeaderBadgeSettingCard";
 
 export default function Settings() {
   return (

--- a/src/popup/components/Settings/index.tsx
+++ b/src/popup/components/Settings/index.tsx
@@ -5,6 +5,7 @@ import HeaderClickSetting from "./HeaderClickSetting";
 import AccessTokenSetting from "./AccessTokenSetting";
 import AnimatedExpandSettingCard from "./AnimatedExpandSettingCard";
 import StatusChecksSettingCard from "./StatusChecksSetting";
+import RepoHeaderBadgeSettingCard from "./RepoHeaderBadgeSetting";
 
 export default function Settings() {
   return (
@@ -12,6 +13,7 @@ export default function Settings() {
       <AccessTokenSetting />
       <HeaderClickSetting />
       <AnimatedExpandSettingCard />
+      <RepoHeaderBadgeSettingCard />
       <StatusChecksSettingCard />
       <ResetStorageSetting />
     </Stack>

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -182,7 +182,7 @@ export function useGetStatusChecksSetting() {
 }
 
 /**
- * A hook to fetch the user's configuration for the Status Checks Setting
+ * A hook to fetch the user's configuration for the Repository Header Badge Setting
  * @returns Returns a loading state variable and the setting value
  */
 export function useGetRepoHeaderBadgeSetting() {

--- a/src/popup/hooks.tsx
+++ b/src/popup/hooks.tsx
@@ -11,6 +11,7 @@ import {
   getStatusChecksSetting,
 } from "../data/extension";
 import GitHubClient, { type RepoData } from "../data";
+import { getRepoHeaderBadgeSetting } from "../data/extension/repoHeaderBadgeSetting";
 
 /**
  * A hook to fetch the currently saved filtering options that was previously
@@ -178,4 +179,30 @@ export function useGetStatusChecksSetting() {
   }, []);
 
   return [statusChecksSetting, setStatusChecksSetting, loading] as const;
+}
+
+/**
+ * A hook to fetch the user's configuration for the Status Checks Setting
+ * @returns Returns a loading state variable and the setting value
+ */
+export function useGetRepoHeaderBadgeSetting() {
+  const [repoHeaderBadgeSetting, setRepoHeaderBadgeSetting] =
+    useState<boolean>(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function getSetting() {
+      const setting = await getRepoHeaderBadgeSetting();
+      setRepoHeaderBadgeSetting(setting);
+    }
+    getSetting()
+      .catch((e) => {
+        console.error("Failed to fetch repo header badge setting", e);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return [repoHeaderBadgeSetting, setRepoHeaderBadgeSetting, loading] as const;
 }


### PR DESCRIPTION
### Summary

In this PR, the badge that was added in the previous PR has been updated to now be a configurable option. The user can now choose to display this badge on a repo section in the settings tab, similar to all the other configurable user settings.

### Changes
- Added extension methods for the repo header badge setting
- Added hooks for the repo header badge setting
- Props for all components have been updated to read the repo header badge setting
- New setting card component for the repo header badge setting

### Screenshot

<details open><summary>Details</summary>
<p>

![image](https://github.com/user-attachments/assets/6b39da7b-222e-464c-a5e0-ad9f811c7d44)


</p>
</details> 
