### PR TITLE
Config Update: Remove unnecessary `tabs` permission

### DIFF
--- a/public/manifest.chrome.json
+++ b/public/manifest.chrome.json
@@ -3,7 +3,7 @@
   "description": "See all of your repo's pull requests in one place!",
   "version": "0.0.3",
   "manifest_version": 3,
-  "permissions": ["alarms", "storage", "tabs"],
+  "permissions": ["alarms", "storage"],
   "background": {
     "service_worker": "background.js"
   },

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "homepage_url": "https://github.com/syj67507/github-pr-chrome-extension",
   "manifest_version": 2,
-  "permissions": ["alarms", "storage", "tabs"],
+  "permissions": ["alarms", "storage"],
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
### Summary

In this PR, the manifest files have been updated so that they no longer have the `tabs` permission. This update has been made (and tested) because the developer dashboard on Chrome rejected the extension due to the [Purple Potassium](https://developer.chrome.com/docs/webstore/troubleshooting/#excessive-permissions) error.

### Changes
- Removed the tabs permission from both manifest files in Chrome and Firefox
- Changes have been tested and no functionality has been lost